### PR TITLE
Scaling's .tag() method fixed in plone.namedfile

### DIFF
--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -68,14 +68,16 @@ class ImageScale(BrowserView):
             ]
         values.extend(kwargs.items())
 
-        parts = ['<img']
+        parts = [u'<img']
         for k, v in values:
             if v is None:
                 continue
             if isinstance(v, int):
                 v = str(v)
-            parts.append("%s=%s" % (k, quoteattr(unicode(v, 'utf8'))))
-        parts.append('/>')
+            elif isinstance(v, str):
+                v = unicode(v, 'utf8')
+            parts.append(u"%s=%s" % (k, quoteattr(v)))
+        parts.append(u'/>')
 
         return u' '.join(parts)
 

--- a/plone/namedfile/tests/test_scaling.py
+++ b/plone/namedfile/tests/test_scaling.py
@@ -61,7 +61,7 @@ class ImageScalingTests(NamedFileTestCase):
         expected_url = re.compile(r'http://nohost/item/@@images/[-a-z0-9]{36}\.jpeg')
         self.failUnless(expected_url.match(foo.absolute_url()))
         self.assertEqual(foo.url, foo.absolute_url())
-        
+
         tag = foo.tag()
         base = self.item.absolute_url()
         expected = r'<img src="%s/@@images/([-0-9a-f]{36}).(jpeg|gif|png)" ' \
@@ -110,7 +110,7 @@ class ImageScalingTests(NamedFileTestCase):
         # the scaling adapter
         self.scaling.available_sizes = {'qux': (12, 12)}
         self.assertEqual(self.scaling.available_sizes, {'qux': (12, 12)})
-    
+
     def testGuardedAccess(self):
         # make sure it's not possible to access scales of forbidden images
         self.item.__allow_access_to_unprotected_subobjects__ = 0
@@ -130,13 +130,21 @@ class ImageScalingTests(NamedFileTestCase):
         expected = r'<img src="%s/@@images/([-0-9a-f]{36}).(jpeg|gif|png)" ' \
             r'alt="foo" title="foo" height="(\d+)" width="(\d+)" />' % base
         self.assertTrue(re.match(expected, tag).groups())
-    
+
     def testScaleOnItemWithNonASCIITitle(self):
         self.item.title = '\xc3\xbc'
         tag = self.scaling.tag('image')
         base = self.item.absolute_url()
         expected = r'<img src="%s/@@images/([-0-9a-f]{36}).(jpeg|gif|png)" ' \
             r'alt="\xfc" title="\xfc" height="(\d+)" width="(\d+)" />' % base
+        self.assertTrue(re.match(expected, tag).groups())
+
+    def testScaleOnItemWithUnicodeTitle(self):
+        self.item.title = u'Unicode here'
+        tag = self.scaling.tag('image')
+        base = self.item.absolute_url()
+        expected = r'<img src="%s/@@images/([-0-9a-f]{36}).(jpeg|gif|png)" ' \
+            r'alt="Unicode here" title="Unicode here" height="(\d+)" width="(\d+)" />' % base
         self.assertTrue(re.match(expected, tag).groups())
 
 
@@ -152,7 +160,7 @@ class ImageTraverseTests(NamedFileTestCase):
 
     def beforeTearDown(self):
         ImageScaling._sizes = self._orig_sizes
-    
+
     def traverse(self, path=''):
         view = self.item.unrestrictedTraverse('@@images')
         stack = path.split('/')
@@ -225,7 +233,7 @@ class ImagePublisherTests(NamedFileFunctionalTestCase):
         self.item = self.app.item
         self.view = self.item.unrestrictedTraverse('@@images')
         self._orig_sizes = ImageScaling._sizes
-    
+
     def beforeTearDown(self):
         ImageScaling._sizes = self._orig_sizes
 
@@ -301,5 +309,5 @@ class ImagePublisherTests(NamedFileFunctionalTestCase):
         self.item.__allow_access_to_unprotected_subobjects__ = 1
 
 def test_suite():
-    from unittest import defaultTestLoader 
+    from unittest import defaultTestLoader
     return defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
In dexterity type view the following was causing Unicode error
        <img tal:define="scale context/@@images"
             tal:replace="structure python: scale.scale('image',
                          scale='mini').tag()" />

Thus, I have added new if in the loop in the tag method to special case unicode-ready values.

Also, scaling has been whitespace cleaned before the change.

Test added to reflect the case.

Thank you,
