### PR TITLE
Fix of img tag attributes for content which contains non ascii characters (common in Dexterity)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.0.6 - unreleased
 ------------------
 
+* Re-fix bug in producing tag for a scale - it should handle both unicode 
+  and non unicode.
+  [naro]
+
 * Fix test failure.
   [davisagli]
 

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -74,7 +74,9 @@ class ImageScale(BrowserView):
                 continue
             if isinstance(v, int):
                 v = str(v)
-            parts.append("%s=%s" % (k, quoteattr(unicode(v, 'utf8'))))
+            if not isinstance(v, unicode):
+                v = unicode(v, 'utf8')
+            parts.append("%s=%s" % (k, quoteattr(v)))
         parts.append('/>')
         
         return u' '.join(parts)

--- a/plone/namedfile/tests/test_scaling.py
+++ b/plone/namedfile/tests/test_scaling.py
@@ -131,8 +131,16 @@ class ImageScalingTests(NamedFileTestCase):
             r'alt="foo" title="foo" height="(\d+)" width="(\d+)" />' % base
         self.assertTrue(re.match(expected, tag).groups())
     
-    def testScaleOnItemWithNonASCIITitle(self):
+    def testScaleOnItemWithNonASCIIEncodedTitle(self):
         self.item.title = '\xc3\xbc'
+        tag = self.scaling.tag('image')
+        base = self.item.absolute_url()
+        expected = r'<img src="%s/@@images/([-0-9a-f]{36}).(jpeg|gif|png)" ' \
+            r'alt="\xfc" title="\xfc" height="(\d+)" width="(\d+)" />' % base
+        self.assertTrue(re.match(expected, tag).groups())
+
+    def testScaleOnItemWithNonASCIIUnicodeTitle(self):
+        self.item.title = '\xc3\xbc'.decode('utf8')
         tag = self.scaling.tag('image')
         base = self.item.absolute_url()
         expected = r'<img src="%s/@@images/([-0-9a-f]{36}).(jpeg|gif|png)" ' \


### PR DESCRIPTION
Re-fix bug in producing tag for a scale - it should handle both unicode and non-unicode
