### PR TITLE
Unicode tag bugfix

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,9 @@ Changelog
 * Fix test failure.
   [davisagli]
 
+* Fix bug in producing tag for a scale on an item with a unicode title
+  [tomster]
+
 1.0.5 - 2011-09-24
 ------------------
 

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -75,7 +75,9 @@ class ImageScale(BrowserView):
                 continue
             if isinstance(v, int):
                 v = str(v)
-            parts.append("%s=%s" % (k, quoteattr(unicode(v, 'utf8'))))
+            elif isinstance(v, str):
+                v = unicode(v, 'utf8')
+            parts.append("%s=%s" % (k, quoteattr(v)))
         parts.append('/>')
 
         return u' '.join(parts)

--- a/plone/namedfile/tests/test_scaling.py
+++ b/plone/namedfile/tests/test_scaling.py
@@ -144,6 +144,14 @@ class ImageScalingTests(NamedFileTestCase):
             r'alt="\xfc" title="\xfc" height="(\d+)" width="(\d+)" />' % base
         self.assertTrue(re.match(expected, tag).groups())
 
+    def testScaleOnItemWithUnicodeTitle(self):
+        self.item.title = u'foo'
+        tag = self.scaling.tag('image')
+        base = self.item.absolute_url()
+        expected = r'<img src="%s/@@images/([-0-9a-f]{36}).(jpeg|gif|png)" ' \
+            r'alt="foo" title="foo" height="(\d+)" width="(\d+)" />' % base
+        self.assertTrue(re.match(expected, tag).groups())
+
 
 class ImageTraverseTests(NamedFileTestCase):
 


### PR DESCRIPTION
On Plone 4.1.2 with dexterity 1.0.3 i observed a `TypeError: decoding Unicode is not supported` when rendering a tag using the following markup:

  `<img tal:replace="structure context/@@images/portrait/preview" />`

where portrait is an instance of a NamedBlobImage field.

it seems dexterity returns the title as unicode which plone.namedfile cannot deal with, since it tries to coerce the title to unicode. with the proposed fix, this now only happens if the title is a string.

is this a viable approach?
