### PR TITLE
Add direction parameter support in scale & tag

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,8 +4,11 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+* Add direction parameter support in scaling (was ignored in tag and scale
+  functions).
+  Now calling tag function with parameter direction='down' crops the image.
+  direction='thumbnail' by default so default behaviour remains the same.
+  [jriboux]
 
 2.0 (2012-08-29)
 ----------------

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -211,7 +211,8 @@ class ImageScaling(BrowserView):
             items, so stored image scales can be invalidated """
         return self.context.modified().millis()
 
-    def scale(self, fieldname=None, scale=None, height=None, width=None, **parameters):
+
+    def scale(self, fieldname=None, scale=None, height=None, width=None, direction='thumbnail', **parameters):
         if fieldname is None:
             fieldname = IPrimaryFieldInfo(self.context).fieldname
         if scale is not None:
@@ -221,12 +222,12 @@ class ImageScaling(BrowserView):
             width, height = available[scale]
         storage = AnnotationStorage(self.context, self.modified)
         info = storage.scale(factory=self.create,
-            fieldname=fieldname, height=height, width=width, **parameters)
+            fieldname=fieldname, height=height, width=width, direction=direction, **parameters)
         if info is not None:
             info['fieldname'] = fieldname
             scale_view = ImageScale(self.context, self.request, **info)
             return scale_view.__of__(self.context)
 
-    def tag(self, fieldname=None, scale=None, height=None, width=None, **kwargs):
-        scale = self.scale(fieldname, scale, height, width)
+    def tag(self, fieldname=None, scale=None, height=None, width=None, direction='thumbnail', **kwargs):
+        scale = self.scale(fieldname, scale, height, width, direction)
         return scale.tag(**kwargs)


### PR DESCRIPTION
Add direction parameter support in scaling (was ignored in tag and scale functions).
Now calling tag function with parameter direction='down' crops the image.
direction='thumbnail' by default so default behaviour remains the same.
