### PR TITLE
Plone 4.3 migration fix

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed handling of TTW Dexterity content type image field
+  data when image data is large and stored as
+  zope.app.file.file.FileChunk in ZODB instead of raw string data.
+  Issue appearated after Plone 4.3 migration [miohtama]
 
 
 2.0.1 (2013-01-17)


### PR DESCRIPTION
After migrating to Plone 4.3, plone.namedfile did not properly handle scaled image data, when images used a lot of data.

Data is provided as zope.app.file.file.FileChunk object by the backend and this is not neither string-like or file-like object. 

The result was that image scales are throwing exceptions which were masked as LocationError.

This patch fixes the behavior by taking FileChunk special case to account when creating image scales.
