### PR TITLE
Workarround for method getImageSize. Prevent returning (-1, -1)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2.0.9 (unreleased)
+------------------
+
+- Workarround for method getImageSize.
+  Prevent returning (-1, -1) as the size of the image.
+  [andreesg]
+
+
 2.0.8 (unreleased)
 ------------------
 

--- a/plone/namedfile/file.py
+++ b/plone/namedfile/file.py
@@ -19,8 +19,6 @@ from ZODB.blob import Blob
 from plone.namedfile.interfaces import INamedBlobFile, INamedBlobImage
 from plone.namedfile.interfaces import IStorage
 
-from PIL import Image
-
 MAXCHUNKSIZE = 1 << 16
 IMAGE_INFO_BYTES = 1024
 MAX_INFO_BYTES = 1 << 16
@@ -458,9 +456,8 @@ class NamedBlobImage(NamedBlobFile):
     def getImageSize(self):
         """See interface `IImage`"""
         if (self._width, self._height) == (-1, -1):
-            stream = StringIO(self.data)
-            im = Image.open(stream)
-            w, h = im.size
-            return (w, h)
+            res = getImageInfo(self.data)
+            contentType, self._width, self._height = res
+            return (self._width, self._height)
         else:
             return (self._width, self._height)

--- a/plone/namedfile/file.py
+++ b/plone/namedfile/file.py
@@ -19,6 +19,8 @@ from ZODB.blob import Blob
 from plone.namedfile.interfaces import INamedBlobFile, INamedBlobImage
 from plone.namedfile.interfaces import IStorage
 
+from PIL import Image
+
 MAXCHUNKSIZE = 1 << 16
 IMAGE_INFO_BYTES = 1024
 MAX_INFO_BYTES = 1 << 16
@@ -455,4 +457,10 @@ class NamedBlobImage(NamedBlobFile):
 
     def getImageSize(self):
         """See interface `IImage`"""
-        return (self._width, self._height)
+        if (self._width, self._height) == (-1, -1):
+            stream = StringIO(self.data)
+            im = Image.open(stream)
+            w, h = im.size
+            return (w, h)
+        else:
+            return (self._width, self._height)


### PR DESCRIPTION
Proposed workarround to prevent getImageSize() method from returning (-1, -1) in certain image files.
Uses PIL to get the correct size of the image.

