### PR TITLE
Make plone.protect a soft dependency.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
-
+- Make plone.protect a soft dependency. This allows to use this package in
+  setups without the Plone stack. Fixes plone/Products.CMFPlone#1311
+  [thet]
 
 3.0.6 (2016-01-08)
 ------------------

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -17,7 +17,12 @@ from zope.interface import implements
 from zope.traversing.interfaces import ITraversable, TraversalError
 from zope.publisher.interfaces import IPublishTraverse, NotFound
 from zope.app.file.file import FileChunk
-from plone.protect.interfaces import IDisableCSRFProtection
+
+try:
+    # Soft dependency to make this package work without plone.protect
+    from plone.protect.interfaces import IDisableCSRFProtection
+except ImportError:
+    IDisableCSRFProtection = None
 
 _marker = object()
 
@@ -310,11 +315,11 @@ class ImageScaling(BrowserView):
             fieldname = IPrimaryFieldInfo(self.context).fieldname
         if scale is not None:
             available = self.getAvailableSizes(fieldname)
-            if not scale in available:
+            if scale not in available:
                 return None
             width, height = available[scale]
 
-        if self.request is not None:
+        if IDisableCSRFProtection and self.request is not None:
             alsoProvides(self.request, IDisableCSRFProtection)
 
         storage = AnnotationStorage(self.context, self.modified)

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -17,12 +17,15 @@ from zope.interface import implements
 from zope.traversing.interfaces import ITraversable, TraversalError
 from zope.publisher.interfaces import IPublishTraverse, NotFound
 from zope.app.file.file import FileChunk
+import pkg_resources
 
 try:
+    pkg_resources.get_distribution('plone.protect>=3.0')
+except (pkg_resources.DistributionNotFound, pkg_resources.VersionConflict):
+    IDisableCSRFProtection = None
+else:
     # Soft dependency to make this package work without plone.protect
     from plone.protect.interfaces import IDisableCSRFProtection
-except ImportError:
-    IDisableCSRFProtection = None
 
 _marker = object()
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(name='plone.namedfile',
           'zope.copy',
           'zope.security',
           'zope.traversing',
-          'plone.protect',
           'plone.rfc822>=1.0b2',
       ],
       extras_require={


### PR DESCRIPTION
This allows to use this package in setups without the Plone stack. Fixes plone/Products.CMFPlone#1311