### PR TITLE
Remove dependency on zope.app.file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ New:
 
 Fixes:
 
+- Remove dependency on ``zope.app.file``, which was only used to import the ``FileChunk`` class, where we have already the same implementation in here.
+  ``zope.app.file`` isn't used in any other Plone core package.
+  [thet]
+
 - PEP 8, UTF-8 headers, implements/adapts to decorators, doctest formating.
   [thet, jensens]
 
@@ -109,31 +113,10 @@ Fixes:
   [thomasdesvenain]
 
 - Fix: get_contenttype works when empty string is given as contentType.
+  [thomasdesvenain]
 
 - Backward compatibility of NamedFile with zope.app.file FileChunk.
   Avoids NamedFile validation unexpected failures.
-  [thomasdesvenain]
-
-
-2.0.5 (2014-02-19)
-------------------
-
-- Ensure zope.app.file.file module alias is created before its use in
-  file package.
-  [thomasdesvenain]
-
-
-2.0.4 (2014-01-27)
-------------------
-
-- Backward compatibility of NamedFile with zope.app.file FileChunk.
-  Avoids NamedFile validation unexpected failures.
-  [thomasdesvenain]
-
-- Validate image field : check if content is actually an image using mimetype.
-  [thomasdesvenain]
-
-- Fix: get_contenttype works when empty string is given as contentType.
   [thomasdesvenain]
 
 

--- a/plone/namedfile/file.py
+++ b/plone/namedfile/file.py
@@ -53,14 +53,6 @@ class FileChunk(Persistent):
         return ''.join(result)
 
 
-FILECHUNK_CLASSES = [FileChunk]
-try:
-    from zope.app.file.file import FileChunk as zafFileChunk
-    FILECHUNK_CLASSES.append(zafFileChunk)
-except ImportError:
-    pass
-
-
 @implementer(INamedFile)
 class NamedFile(Persistent):
     """A non-BLOB file that stores a filename
@@ -165,7 +157,7 @@ class NamedFile(Persistent):
         self.filename = filename
 
     def _getData(self):
-        if isinstance(self._data, tuple(FILECHUNK_CLASSES)):
+        if isinstance(self._data, FileChunk):
             return str(self._data)
         else:
             return self._data
@@ -185,7 +177,7 @@ class NamedFile(Persistent):
             raise TypeError('Cannot set None data on a file.')
 
         # Handle case when data is already a FileChunk
-        if isinstance(data, tuple(FILECHUNK_CLASSES)):
+        if isinstance(data, FileChunk):
             size = len(data)
             self._data, self._size = data, size
             return

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -3,6 +3,7 @@ from AccessControl.ZopeGuards import guarded_getattr
 from Acquisition import aq_base
 from DateTime import DateTime
 from logging import exception
+from plone.namedfile.file import FileChunk
 from plone.namedfile.interfaces import IAvailableSizes
 from plone.namedfile.interfaces import IStableImageScale
 from plone.namedfile.utils import set_headers
@@ -13,7 +14,6 @@ from plone.scale.storage import AnnotationStorage
 from Products.Five import BrowserView
 from xml.sax.saxutils import quoteattr
 from ZODB.POSException import ConflictError
-from zope.app.file.file import FileChunk
 from zope.component import queryUtility
 from zope.interface import alsoProvides
 from zope.interface import implementer

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
     install_requires=[
         'setuptools',
         'plone.rfc822>=1.0b2',
-        'zope.app.file',
         'zope.browserpage',
         'zope.component',
         'zope.copy',


### PR DESCRIPTION
Remove dependency on ``zope.app.file``, which was only used to import the ``FileChunk`` class, where we have already the same implementation in here.
``zope.app.file`` isn't used in any other Plone core package.

/cc @tdesvenain - you've added the dependency on zope.app.file - are you ok with removing it again?
no core package seems to depend on zope.app.file - nor any of our zope dependencies. so this seems superfluous.

tests running...