### PR TITLE
feat: add SVG support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Incompatibilities:
 
 New:
 
-- *add item here*
+- Add SVG support.
+  [Gagaro]
 
 Fixes:
 

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -328,13 +328,17 @@ class ImageScaling(BrowserView):
         if IDisableCSRFProtection and self.request is not None:
             alsoProvides(self.request, IDisableCSRFProtection)
 
-        storage = AnnotationStorage(self.context, self.modified)
-        info = storage.scale(factory=self.create,
-                             fieldname=fieldname,
-                             height=height,
-                             width=width,
-                             direction=direction,
-                             **parameters)
+        image = getattr(self.context, fieldname)
+        if image is not None and getattr(image, 'contentType', '') == 'image/svg+xml':
+            info = {'data': None, 'width': width, 'height': height}
+        else:
+            storage = AnnotationStorage(self.context, self.modified)
+            info = storage.scale(factory=self.create,
+                                 fieldname=fieldname,
+                                 height=height,
+                                 width=width,
+                                 direction=direction,
+                                 **parameters)
 
         if info is not None:
             info['fieldname'] = fieldname

--- a/plone/namedfile/tests/test_image.py
+++ b/plone/namedfile/tests/test_image.py
@@ -30,6 +30,17 @@ zptlogo = (
     '\x00A\x00;'
 )
 
+svg_image = (
+    '<?xml version="1.0" encoding="utf-8"?>'
+    '<svg xmlns="http://www.w3.org/2000/svg"'
+    ' version="1.1" width="300" height="200">'
+    '<rect width="100" height="80" x="0" y="70" fill="green" />'
+    '<line x1="5" y1="5" x2="250" y2="95" stroke="red" />'
+    '<circle cx="90" cy="80" r="50" fill="blue" />'
+    '<text x="180" y="60">Un texte</text>'
+    '</svg>'
+)
+
 
 class TestImage(unittest.TestCase):
 
@@ -56,6 +67,12 @@ class TestImage(unittest.TestCase):
         self.assertEqual(image.data, zptlogo)
         self.assertEqual(image.contentType, 'image/gif')
         self.assertEqual(image.getImageSize(), (16, 16))
+
+    def testSvg(self):
+        image = self._makeImage(data=svg_image)
+        self.assertEqual(image.contentType, 'image/svg+xml')
+        self.assertEqual(image._width, 300)
+        self.assertEqual(image._height, 200)
 
     def testInterface(self):
         self.assertTrue(INamedImage.implementedBy(NamedImage))


### PR DESCRIPTION
Do not merge right now.

I started to add support for SVG images. The idea is to always use the original image for all scaling (as it is vectoriel, only the end image size needs to be known). It works fine when using tag() directly, but not when using a url of the form "/@@images/image/icon".

The only way I see would be to resize the SVG files one or another (which would render the use of svg quite useless). Or we would have to edit all template using the traversal, which would be really tedious.

Does anyone has another idea or something which could help with this?
