### PR TITLE
Re added Compatibility for Plone 4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ Bug fixes:
 - Fix: Do not log failing PIL image regognition as error, but as warning.
   [jensens]
 
+- Fix: compatibility for Plone 4 re-added.
+  [loechel]
+
 
 4.2.0 (2017-03-26)
 ------------------

--- a/plone/namedfile/utils/__init__.py
+++ b/plone/namedfile/utils/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from logging import getLogger
-from plone import api
 from plone.namedfile.interfaces import IBlobby
 from plone.namedfile.utils.jpeg_utils import process_jpeg
 from plone.namedfile.utils.png_utils import process_png
@@ -269,27 +268,21 @@ def rotate_image(image_data, method=None, REQUEST=None):
 
 
 def getRetinaScales():
-    registry = queryUtility(IRegistry)
-    if not registry:
-        return []
-    if api.env.plone_version() >= '5.0':
+    try:
         from Products.CMFPlone.interfaces.controlpanel import IImagingSchema
-        settings = registry.forInterface(
-            IImagingSchema, prefix='plone', check=False)
-
-    if settings and settings.retina_scales == '2x':
-        return [{
-            'scale': 2,
-            'quality': settings.quality_2x,
-        }]
-    elif settings and settings.retina_scales == '3x':
-        return [
-            {
-                'scale': 2,
-                'quality': settings.quality_2x,
-            },
-            {
-                'scale': 3,
-                'quality': settings.quality_3x,
-            }]
+        registry = queryUtility(IRegistry)
+        if registy:
+            settings = registry.forInterface(
+                IImagingSchema, prefix='plone', check=False)
+            if settings.retina_scales == '2x':
+                return [
+                    {'scale': 2, 'quality': settings.quality_2x},
+                ]
+            elif settings.retina_scales == '3x':
+                return [
+                    {'scale': 2, 'quality': settings.quality_2x},
+                    {'scale': 3, 'quality': settings.quality_3x},
+                ]
+    except ImportError:
+        log.info('IImagingSchema for Retina Scales not importable.')
     return []

--- a/plone/namedfile/utils/__init__.py
+++ b/plone/namedfile/utils/__init__.py
@@ -19,6 +19,12 @@ import urllib
 
 log = getLogger(__name__)
 
+try:
+    from Products.CMFPlone.interfaces.controlpanel import IImagingSchema
+except ImportError:
+    IImagingSchema = None
+    log.info('IImagingSchema for Retina Scales not available.')
+
 
 try:
     # use this to stream data if we can
@@ -268,21 +274,17 @@ def rotate_image(image_data, method=None, REQUEST=None):
 
 
 def getRetinaScales():
-    try:
-        from Products.CMFPlone.interfaces.controlpanel import IImagingSchema
-        registry = queryUtility(IRegistry)
-        if registy:
-            settings = registry.forInterface(
-                IImagingSchema, prefix='plone', check=False)
-            if settings.retina_scales == '2x':
-                return [
-                    {'scale': 2, 'quality': settings.quality_2x},
-                ]
-            elif settings.retina_scales == '3x':
-                return [
-                    {'scale': 2, 'quality': settings.quality_2x},
-                    {'scale': 3, 'quality': settings.quality_3x},
-                ]
-    except ImportError:
-        log.info('IImagingSchema for Retina Scales not importable.')
+    registry = queryUtility(IRegistry)
+    if IImagingSchema and registry:
+        settings = registry.forInterface(
+            IImagingSchema, prefix='plone', check=False)
+        if settings.retina_scales == '2x':
+            return [
+                {'scale': 2, 'quality': settings.quality_2x},
+            ]
+        elif settings.retina_scales == '3x':
+            return [
+                {'scale': 2, 'quality': settings.quality_2x},
+                {'scale': 3, 'quality': settings.quality_3x},
+            ]
     return []

--- a/plone/namedfile/utils/__init__.py
+++ b/plone/namedfile/utils/__init__.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from logging import getLogger
+from plone import api
 from plone.namedfile.interfaces import IBlobby
 from plone.namedfile.utils.jpeg_utils import process_jpeg
 from plone.namedfile.utils.png_utils import process_png
 from plone.namedfile.utils.tiff_utils import process_tiff
 from plone.registry.interfaces import IRegistry
-from Products.CMFPlone.interfaces.controlpanel import IImagingSchema
 from StringIO import StringIO
 from zope.component import queryUtility
 
@@ -16,6 +16,10 @@ import piexif
 import PIL.Image
 import struct
 import urllib
+
+if api.env.plone_version() >= '5.0':
+    import pdb; pdb.set_trace()
+    from Products.CMFPlone.interfaces.controlpanel import IImagingSchema
 
 
 log = getLogger(__name__)
@@ -272,14 +276,16 @@ def getRetinaScales():
     registry = queryUtility(IRegistry)
     if not registry:
         return []
-    settings = registry.forInterface(
-        IImagingSchema, prefix='plone', check=False)
-    if settings.retina_scales == '2x':
+    if api.env.plone_version() >= '5.0':
+        settings = registry.forInterface(
+            IImagingSchema, prefix='plone', check=False)
+
+    if settings and settings.retina_scales == '2x':
         return [{
             'scale': 2,
             'quality': settings.quality_2x,
         }]
-    if settings.retina_scales == '3x':
+    elif settings and settings.retina_scales == '3x':
         return [
             {
                 'scale': 2,

--- a/plone/namedfile/utils/__init__.py
+++ b/plone/namedfile/utils/__init__.py
@@ -17,10 +17,6 @@ import PIL.Image
 import struct
 import urllib
 
-if api.env.plone_version() >= '5.0':
-    import pdb; pdb.set_trace()
-    from Products.CMFPlone.interfaces.controlpanel import IImagingSchema
-
 
 log = getLogger(__name__)
 
@@ -277,6 +273,7 @@ def getRetinaScales():
     if not registry:
         return []
     if api.env.plone_version() >= '5.0':
+        from Products.CMFPlone.interfaces.controlpanel import IImagingSchema
         settings = registry.forInterface(
             IImagingSchema, prefix='plone', check=False)
 


### PR DESCRIPTION
Hi,

I need the plone.namedfile >= 4.2 for a Plone 4.3 project, it works well, if the Retina Scale Interface is explizite checked to exists / Plone Version Check >= 5 and then it works also in Plone 4.3