### PR TITLE
different caching keys for different domains

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Bug fixes:
 - Dont't break DefaultImageScalingFactory, if for any reason the fieldname isn't available on the context.
   [thet]
 
+- Different caching keys for different domains
+  [mamico]
+
 
 4.2.1 (2017-05-30)
 ------------------

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -492,7 +492,7 @@ class ImageScaling(BrowserView):
 
 class NavigationRootScaling(ImageScaling):
     def _scale_cachekey(method, self, brain, fieldname, **kwargs):
-        return (brain.UID, brain.modified, fieldname, kwargs)
+        return (self.context.absolute_url(), brain.UID, brain.modified, fieldname, kwargs)
 
     @ram.cache(_scale_cachekey)
     def tag(self,


### PR DESCRIPTION
absolute_url not provided on the cache storage key implies incorrect image url when the same content comes with different URLs/domains. 

Problem encountered, for example, with news portlets: https://github.com/plone/plone.app.portlets/blob/master/plone/app/portlets/portlets/news.pt#L35 or navigation: https://github.com/plone/plone.app.portlets/blob/9bdd2b23a8427731d491bcf1306f78459393df62/plone/app/portlets/portlets/navigation_recurse.pt#L43