### PR TITLE
Allow access to namedfile attributes from restricted Python

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,11 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Allow restricted Python to access public file attributes and helper
+  methods (mainly ``filename``, ``contentType``, ``data``, ``getSize`` and
+  ``getImageSize``)
+  by setting ``__allow_access_to_unprotected_subobjects__ = 1``
+  [datakurre]
 
 Bug fixes:
 

--- a/plone/namedfile/file.py
+++ b/plone/namedfile/file.py
@@ -158,6 +158,8 @@ class NamedFile(Persistent):
     True
     """
 
+    __allow_access_to_unprotected_subobjects__ = 1  # pass Zope2 AccessControl
+
     filename = FieldProperty(INamedFile['filename'])
 
     def __init__(self, data='', contentType='', filename=None):
@@ -308,6 +310,8 @@ class NamedImage(NamedFile):
 @implementer(INamedBlobFile)
 class NamedBlobFile(Persistent):
     """A file stored in a ZODB BLOB, with a filename"""
+
+    __allow_access_to_unprotected_subobjects__ = 1  # pass Zope2 AccessControl
 
     filename = FieldProperty(INamedFile['filename'])
 


### PR DESCRIPTION
Any reason why attributes should not be accessible? Attributes and methods starting with _ remain protected.

This would allow e.g. to write "maximum file size validator" using collective.ambidexterity.