### PR TITLE
Fixes an issue where the filesize was not extracted properly from an image with lots of metadata.

### DIFF
--- a/news/74.bugfix
+++ b/news/74.bugfix
@@ -1,0 +1,1 @@
+Increase static MAX_INFO_BYTES to fix an issue where the filesize was not extracted properly from an image with lots of metadata. [elioschmutz]

--- a/plone/namedfile/file.py
+++ b/plone/namedfile/file.py
@@ -28,7 +28,7 @@ log = getLogger(__name__)
 
 MAXCHUNKSIZE = 1 << 16
 IMAGE_INFO_BYTES = 1024
-MAX_INFO_BYTES = 1 << 16
+MAX_INFO_BYTES = 1 << 18
 
 
 class FileChunk(Persistent):


### PR DESCRIPTION
Increase static MAX_INFO_BYTES to fix an issue where the filesize was not extracted properly from an image with lots of metadata.

The [algorithm](https://github.com/plone/plone.namedfile/blob/2.0.x/plone/namedfile/file.py#L321) for extracting the filesize is searching for the `SOF0`-marker which contains the required file-size information. (See spec: http://vip.sugovica.hu/Sardi/kepnezo/JPEG%20File%20Layout%20and%20Format.htm, here, the algorithm is searching for the `SOF0` marker which is identified by `0xc0` https://github.com/plone/plone.namedfile/blob/2.0.x/plone/namedfile/file.py#L333)

The `jpeg` specifications defines that the header can be up to 4*2^16 bytes. And the `SOF0`-section is the last one of the header-sections. But the `NamdedBlobImage` only uses 2^16 bytes as info-bytes.

Having an image with a lot of metadata, i.e. it is usual with images made with cameras (i.e. EXIF-Metadata: https://de.wikipedia.org/wiki/Exchangeable_Image_File_Format), the configured `MAX_INFO_BYTES` will not contain the required file-size.

Increasing the `MAX_INFO_BYTES` to the potential possible max-size will solve this problem. 

Fixes #74 