### PR TITLE
Set alt attribute in tag method by default

### DIFF
--- a/news/76.feature
+++ b/news/76.feature
@@ -1,0 +1,2 @@
+Change scale method logic: don't return a redundant title attr for images, but set `alt` attribute from a new alt_text field.
+[cekk]

--- a/news/76.feature
+++ b/news/76.feature
@@ -1,2 +1,2 @@
-Change scale method logic: don't return a redundant title attr for images, but set `alt` attribute from a new alt_text field.
+Change tag method logic: don't return a useless title attr for images, but set `alt` attribute from a new alt_text field.
 [cekk]

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -83,15 +83,14 @@ class ImageScale(BrowserView):
             css_class=None, title=_marker, **kwargs):
         """Create a tag including scale
         """
+
         if height is _marker:
             height = getattr(self, 'height', self.data._height)
         if width is _marker:
             width = getattr(self, 'width', self.data._width)
 
         if alt is _marker:
-            alt = self.context.Title()
-        if title is _marker:
-            title = self.context.Title()
+            alt = getattr(self.context, 'alt_text', '')
 
         values = [
             ('src', self.url),
@@ -110,7 +109,7 @@ class ImageScale(BrowserView):
 
         parts = ['<img']
         for k, v in values:
-            if v is None:
+            if v in [None, _marker]:
                 continue
             if isinstance(v, int):
                 v = str(v)
@@ -334,7 +333,8 @@ class ImageScaling(BrowserView):
             return ImmutableTraverser(self.scale(name, furtherPath[-1]))
 
         if image is not None:
-            return image.tag()
+            alt_text = getattr(self.context, 'alt_text', '')
+            return image.tag(alt=alt_text, title=None)
         raise TraversalError(self, name)
 
     _sizes = {}

--- a/plone/namedfile/tests/test_scaling.py
+++ b/plone/namedfile/tests/test_scaling.py
@@ -123,7 +123,7 @@ class ImageScalingTests(unittest.TestCase):
         base = self.item.absolute_url()
         expected = \
             r'<img src="{0}/@@images/([-0-9a-f]{{36}}).(jpeg|gif|png)" ' \
-            r'alt="foo" title="foo" height="(\d+)" width="(\d+)" />'.format(
+            r'alt="" height="(\d+)" width="(\d+)" />'.format(
                 base,
             )
         groups = re.match(expected, tag).groups()
@@ -145,7 +145,7 @@ class ImageScalingTests(unittest.TestCase):
             r'<img src="{0}'.format(base) +
             r'/@@images/([-0-9a-f]{36})'
             r'.(jpeg|gif|png)" '
-            r'alt="foo" title="foo" height="(\d+)" width="(\d+)" '
+            r'alt="" height="(\d+)" width="(\d+)" '
             r'srcset="http://nohost/item/@@images/([-0-9a-f]{36})'
             r'.(jpeg|gif|png)'
             r' 2x" />')
@@ -167,7 +167,7 @@ class ImageScalingTests(unittest.TestCase):
             r'<img src="{0}'.format(base) +
             r'/@@images/([-0-9a-f]{36})'
             r'.(jpeg|gif|png)" '
-            r'alt="foo" title="foo" height="(\d+)" width="(\d+)" '
+            r'alt="" height="(\d+)" width="(\d+)" '
             r'srcset="http://nohost/item/@@images/([-0-9a-f]{36})'
             r'.(jpeg|gif|png)'
             r' 2x" />')
@@ -189,7 +189,7 @@ class ImageScalingTests(unittest.TestCase):
             r'<img src="{0}'.format(base) +
             r'/@@images/([-0-9a-f]{36})'
             r'.(jpeg|gif|png)" '
-            r'alt="foo" title="foo" height="(\d+)" width="(\d+)" '
+            r'alt="" height="(\d+)" width="(\d+)" '
             r'srcset="http://nohost/item/@@images/([-0-9a-f]{36})'
             r'.(jpeg|gif|png)'
             r' 2x" />')
@@ -211,7 +211,7 @@ class ImageScalingTests(unittest.TestCase):
             r'<img src="{0}'.format(base) +
             r'/@@images/([-0-9a-f]{36})'
             r'.(jpeg|gif|png)" '
-            r'alt="foo" title="foo" height="(\d+)" width="(\d+)" '
+            r'alt="" height="(\d+)" width="(\d+)" '
             r'srcset="http://nohost/item/@@images/([-0-9a-f]{36})'
             r'.(jpeg|gif|png)'
             r' 2x" />')
@@ -282,7 +282,7 @@ class ImageScalingTests(unittest.TestCase):
         base = self.item.absolute_url()
         expected = \
             r'<img src="{0}/@@images/([-0-9a-f]{{36}}).(jpeg|gif|png)" ' \
-            r'alt="foo" title="foo" height="(\d+)" width="(\d+)" />'.format(
+            r'alt="" height="(\d+)" width="(\d+)" />'.format(
                 base,
             )
         self.assertTrue(re.match(expected, tag).groups())
@@ -293,7 +293,7 @@ class ImageScalingTests(unittest.TestCase):
         base = self.item.absolute_url()
         expected = \
             r'<img src="{0}/@@images/([-0-9a-f]{{36}}).(jpeg|gif|png)" ' \
-            r'alt="\xfc" title="\xfc" height="(\d+)" width="(\d+)" />'.format(
+            r'alt="" height="(\d+)" width="(\d+)" />'.format(
                 base,
             )
         self.assertTrue(re.match(expected, tag).groups())
@@ -304,7 +304,7 @@ class ImageScalingTests(unittest.TestCase):
         base = self.item.absolute_url()
         expected = \
             r'<img src="{0}/@@images/([-0-9a-f]{{36}}).(jpeg|gif|png)" ' \
-            r'alt="\xfc" title="\xfc" height="(\d+)" width="(\d+)" />'.format(
+            r'alt="" height="(\d+)" width="(\d+)" />'.format(
                 base,
             )
         self.assertTrue(re.match(expected, tag).groups())
@@ -369,7 +369,7 @@ class ImageTraverseTests(unittest.TestCase):
         base = self.item.absolute_url()
         expected = \
             r'<img src="{0}/@@images/([-0-9a-f]{{36}}).(jpeg|gif|png)" ' \
-            r'alt="foo" title="foo" height="(\d+)" width="(\d+)" />'.format(
+            r'alt="" height="(\d+)" width="(\d+)" />'.format(
                 base,
             )
         groups = re.match(expected, tag).groups()
@@ -426,6 +426,59 @@ class ImageTraverseTests(unittest.TestCase):
         ImageScaling._sizes = {'foo': (42, 42)}
         self.assertRaises(Unauthorized, self.traverse, 'image/foo')
         self.item.__allow_access_to_unprotected_subobjects__ = 1
+
+
+class ImageScalingAltTextTests(unittest.TestCase):
+
+    layer = PLONE_NAMEDFILE_INTEGRATION_TESTING
+
+    def setUp(self):
+        data = getFile('image.png')
+        item = DummyContent()
+        item.image = NamedImage(data, 'image/png', u'image.png')
+        item.alt_text = 'example alt'
+        self.layer['app']._setOb('item', item)
+        self.item = self.layer['app'].item
+        self.scaling = ImageScaling(self.item, None)
+
+    def testShowAltInScale(self):
+        self.scaling.available_sizes = {'foo': (60, 60)}
+        foo = self.scaling.scale('image', scale='foo')
+        tag = foo.tag()
+        base = self.item.absolute_url()
+        expected = \
+            r'<img src="{0}/@@images/([-0-9a-f]{{36}}).(jpeg|gif|png)" ' \
+            r'alt="example alt" height="(\d+)" width="(\d+)" />'.format(
+                base,
+            )
+        groups = re.match(expected, tag).groups()
+        self.assertTrue(groups, tag)
+
+    def testShowCustomAltInScale(self):
+        self.scaling.available_sizes = {'foo': (60, 60)}
+        foo = self.scaling.scale('image', scale='foo')
+        tag = foo.tag(alt='custom alt')
+        base = self.item.absolute_url()
+        expected = \
+            r'<img src="{0}/@@images/([-0-9a-f]{{36}}).(jpeg|gif|png)" ' \
+            r'alt="custom alt" height="(\d+)" width="(\d+)" />'.format(
+                base,
+            )
+        groups = re.match(expected, tag).groups()
+        self.assertTrue(groups, tag)
+    
+    def testShowTitleIfPassed(self):
+        self.scaling.available_sizes = {'foo': (60, 60)}
+        foo = self.scaling.scale('image', scale='foo')
+        tag = foo.tag(title='custom title')
+        base = self.item.absolute_url()
+        expected = \
+            r'<img src="{0}/@@images/([-0-9a-f]{{36}}).(jpeg|gif|png)" ' \
+            r'alt="example alt" title="custom title" height="(\d+)" width="(\d+)" />'.format(
+                base,
+            )
+        groups = re.match(expected, tag).groups()
+        self.assertTrue(groups, tag)
 
 
 def test_suite():


### PR DESCRIPTION
Fixes #76 

Tag method shouldn't return a useless title attribute, so right now it is optional.
Alt tag shouldn't be redundant, so it cannot be the title or description. Right now it reads new _alt_text_ attribute from Image content-type and lead image and return it as _alt_ html attribute.