### PR TITLE
fix multiple write during image requests

### DIFF
--- a/news/78.bugfix
+++ b/news/78.bugfix
@@ -1,0 +1,2 @@
+fix multiple write during image requests
+[mamico]

--- a/plone/namedfile/file.py
+++ b/plone/namedfile/file.py
@@ -409,7 +409,15 @@ class NamedBlobImage(NamedBlobFile):
             length = max(0, MAX_INFO_BYTES - start)
             firstbytes += self.getFirstBytes(start, length)
             res = getImageInfo(firstbytes)
+        
         contentType, self._width, self._height = res
+        
+        if (self._width, self._height) == (-1, -1):
+            # not enough information on firstbytes to guess width/height ?
+            # TODO: missing problematic file on tests
+            # see https://github.com/plone/plone.namedfile/pull/11
+            contentType, self._width, self._height = getImageInfo(data)
+
         if contentType:
             self.contentType = contentType
 
@@ -428,8 +436,4 @@ class NamedBlobImage(NamedBlobFile):
 
     def getImageSize(self):
         """See interface `IImage`"""
-        if (self._width, self._height) != (-1, -1):
-            return (self._width, self._height)
-
-        contentType, self._width, self._height = getImageInfo(self.data)
         return (self._width, self._height)


### PR DESCRIPTION
This problem starts in #11 with getImageSize, where if width/height are not correctly extracted 
during ``__init__`` or ``setData`` (i.e. equals to (-1, -1)), then getImageInfo is called again and the 
new values are saved on _width and _height attributes.

The main problem is that getImageSize is called during every view request, and if sizes are never
exctacted correctly writes happens everytime.

I've moved this second try to guess the size on setData method.

We experienced the problem on a busy site using SVG images that, according to the code in 
plone.namedfile, had width/height equal to (-1, -1)... and therefore a lot of writes and ConflictError....