### PR TITLE
Pluggable validation using adapters

### DIFF
--- a/news/81.feature
+++ b/news/81.feature
@@ -1,0 +1,6 @@
+Add new interface ``plone.namedfile.interfaces.IPluggableFileFieldValidation`` and ``plone.namedfile.interfaces.IPluggableImageFieldValidation``.
+Refactored: the fields validation now looks for adapters with this interfaces adapting field and value.
+All found adapters are called.
+The image content type checker (existed before) is by now the only adapter implemented and registered so far.
+Other adapters can be registered in related or custom code.
+[jensens]

--- a/plone/namedfile/configure.zcml
+++ b/plone/namedfile/configure.zcml
@@ -22,5 +22,6 @@
   <include file="marshaler.zcml" />
   <include file="scaling.zcml" />
   <include file="editor.zcml" />
+  <include file="field.zcml" />
 
 </configure>

--- a/plone/namedfile/field.py
+++ b/plone/namedfile/field.py
@@ -74,7 +74,7 @@ class NamedFile(Object):
         super(NamedFile, self).__init__(schema=self.schema, **kw)
 
     def _validate(self, value):
-        super(NamedBlobImage, self)._validate(value)
+        super(NamedFile, self)._validate(value)
         validate_file_field(self, value)
 
 
@@ -110,7 +110,7 @@ class NamedBlobFile(Object):
         super(NamedBlobFile, self).__init__(schema=self.schema, **kw)
 
     def _validate(self, value):
-        super(NamedBlobImage, self)._validate(value)
+        super(NamedBlobFile, self)._validate(value)
         validate_file_field(self, value)
 
 

--- a/plone/namedfile/field.py
+++ b/plone/namedfile/field.py
@@ -11,9 +11,14 @@ from plone.namedfile.interfaces import INamedFile
 from plone.namedfile.interfaces import INamedFileField
 from plone.namedfile.interfaces import INamedImage
 from plone.namedfile.interfaces import INamedImageField
+from plone.namedfile.interfaces import IPluggableFileFieldValidation
+from plone.namedfile.interfaces import IPluggableImageFieldValidation
 from plone.namedfile.utils import get_contenttype
+from zope.component import adapter
+from zope.component import getAdapters
 from zope.i18nmessageid import MessageFactory
 from zope.interface import implementer
+from zope.interface import Interface
 from zope.schema import Object
 from zope.schema import ValidationError
 
@@ -21,16 +26,38 @@ from zope.schema import ValidationError
 _ = MessageFactory('plone')
 
 
+@implementer(IPluggableImageFieldValidation)
+@adapter(INamedImageField, Interface)
+class ImageContenttypeValidator(object):
+
+    def __init__(self, field, value):
+        self.field = field
+        self.value = value
+
+    def __call__(self):
+        if self.value is None:
+            return
+        mimetype = get_contenttype(self.value)
+        if mimetype.split('/')[0] != 'image':
+            raise InvalidImageFile(mimetype, self.field.__name__)
+
+
 class InvalidImageFile(ValidationError):
     """Exception for invalid image file"""
     __doc__ = _(u'Invalid image file')
 
 
+def validate_binary_field(interface, field, value):
+    for name, validator in getAdapters((field, value), interface):
+        validator()
+
+
 def validate_image_field(field, value):
-    if value is not None:
-        mimetype = get_contenttype(value)
-        if mimetype.split('/')[0] != 'image':
-            raise InvalidImageFile(mimetype, field.__name__)
+    validate_binary_field(IPluggableImageFieldValidation, field, value)
+
+
+def validate_file_field(field, value):
+    validate_binary_field(IPluggableFileFieldValidation, field, value)
 
 
 @implementer(INamedFileField)
@@ -45,6 +72,10 @@ class NamedFile(Object):
         if 'schema' in kw:
             self.schema = kw.pop('schema')
         super(NamedFile, self).__init__(schema=self.schema, **kw)
+
+    def _validate(self, value):
+        super(NamedBlobImage, self)._validate(value)
+        validate_file_field(self, value)
 
 
 @implementer(INamedImageField)
@@ -77,6 +108,10 @@ class NamedBlobFile(Object):
         if 'schema' in kw:
             self.schema = kw.pop('schema')
         super(NamedBlobFile, self).__init__(schema=self.schema, **kw)
+
+    def _validate(self, value):
+        super(NamedBlobImage, self)._validate(value)
+        validate_file_field(self, value)
 
 
 @implementer(INamedBlobImageField)

--- a/plone/namedfile/field.zcml
+++ b/plone/namedfile/field.zcml
@@ -1,0 +1,11 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+    <adapter
+        factory=".field.ImageContenttypeValidator"
+        name="image_contenttype"
+    />
+
+</configure>

--- a/plone/namedfile/interfaces.py
+++ b/plone/namedfile/interfaces.py
@@ -59,6 +59,26 @@ except ImportError:
         """
 
 
+class IPluggableBinaryFieldValidation(Interface):
+
+    def validate(field, value):
+        """validates field and value.
+
+        raises zope.schema.ValidationError
+        returns None
+        """
+
+
+class IPluggableFileFieldValidation(IPluggableBinaryFieldValidation):
+    """pluggable validation for binary File fields
+    """
+
+
+class IPluggableImageFieldValidation(IPluggableBinaryFieldValidation):
+    """pluggable validation for binary Image fields
+    """
+
+
 # Values
 
 class INamed(Interface):

--- a/plone/namedfile/interfaces.py
+++ b/plone/namedfile/interfaces.py
@@ -61,7 +61,7 @@ except ImportError:
 
 class IPluggableBinaryFieldValidation(Interface):
 
-    def validate(field, value):
+    def __call__(field, value):
         """validates field and value.
 
         raises zope.schema.ValidationError

--- a/plone/namedfile/tests/test_image.py
+++ b/plone/namedfile/tests/test_image.py
@@ -5,6 +5,7 @@ from plone.namedfile.file import NamedImage
 from plone.namedfile.interfaces import INamedImage
 from plone.namedfile.tests import getFile
 from plone.namedfile.utils import get_contenttype
+from plone.namedfile.testing import PLONE_NAMEDFILE_INTEGRATION_TESTING
 from zope.interface.verify import verifyClass
 
 import unittest
@@ -79,10 +80,21 @@ class TestImage(unittest.TestCase):
                        filename=u'notimage.doc')),
             'application/msword')
 
-    def testImageValidation(self):
-        from plone.namedfile.field import InvalidImageFile,\
-            validate_image_field
 
+class TestValidation(unittest.TestCase):
+
+    layer = PLONE_NAMEDFILE_INTEGRATION_TESTING
+
+    def _makeImage(self, *args, **kw):
+        return NamedImage(*args, **kw)
+
+    def testImageValidation(self):
+        from plone.namedfile.field import InvalidImageFile
+        from plone.namedfile.field import validate_image_field
+        from plone.namedfile.interfaces import INamedImageField
+        from zope.interface import implementer
+
+        @implementer(INamedImageField)
         class FakeField(object):
             __name__ = 'logo'
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 import os
 
 
-version = '5.0.5.dev0'
+version = '5.1.0.dev0'
 description = 'File types and fields for images, files and blob files with ' \
               'filenames'
 long_description = ('\n\n'.join([


### PR DESCRIPTION
Use case is to have a way to register specific checks for uploads. One is the maximum file size.
The specific adapter will be handled outside of plone.namedfile. But here we lay the infrastructure.