### PR TITLE
Change to use field value _p_mtime instead of context object _p_mtime…

### DIFF
--- a/news/91.feature
+++ b/news/91.feature
@@ -1,0 +1,1 @@
+- Change to use field value _p_mtime instead of context object _p_mtime as image scale invalidation timestamp to fix issue where context object (e.g. a document with lead image) modification invalidated all its image field scales even the images itself were not modified. [datakurre]


### PR DESCRIPTION
… as image scale invalidation timestamp

Because currently updating a content with image field invalidates image scales for its every image field even when image field itself are not touched during update. This has become a performance issue with lead image documents, especially on Volto.