### PR TITLE
Fix image scaling to return the originals when no scaling is required

### DIFF
--- a/news/92.bugfix
+++ b/news/92.bugfix
@@ -1,0 +1,1 @@
+- Fix image scaling to re-use the original image when scaling is not required to allow Plone REST API to use cacheable scale URL for the original image without performance penalty [datakurre]

--- a/news/92.bugfix
+++ b/news/92.bugfix
@@ -1,1 +1,1 @@
-- Fix image scaling to re-use the original image when scaling is not required to allow Plone REST API to use cacheable scale URL for the original image without performance penalty [datakurre]
+Fix image scaling to re-use the original image when scaling is not required to allow Plone REST API to use cacheable scale URL for the original image without performance penalty [datakurre]

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -218,6 +218,10 @@ class DefaultImageScalingFactory(object):
         if height is None and width is None:
             dummy, format_ = orig_value.contentType.split("/", 1)
             return None, format_, (orig_value._width, orig_value._height)
+        elif height == orig_value._height and width == orig_value._width:
+            if not parameters:
+                dummy, format_ = orig_value.contentType.split("/", 1)
+                return orig_value, format_, (orig_value._width, orig_value._height)
         orig_data = None
         try:
             orig_data = orig_value.open()

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -218,10 +218,11 @@ class DefaultImageScalingFactory(object):
         if height is None and width is None:
             dummy, format_ = orig_value.contentType.split("/", 1)
             return None, format_, (orig_value._width, orig_value._height)
-        elif height == orig_value._height and width == orig_value._width:
-            if not parameters:
-                dummy, format_ = orig_value.contentType.split("/", 1)
-                return orig_value, format_, (orig_value._width, orig_value._height)
+        elif not parameters and height and width \
+                and height == getattr(orig_value, "_height", None) \
+                and width == getattr(orig_value, "_width", None):
+            dummy, format_ = orig_value.contentType.split("/", 1)
+            return orig_value, format_, (orig_value._width, orig_value._height)
         orig_data = None
         try:
             orig_data = orig_value.open()

--- a/plone/namedfile/tests/test_scaling.py
+++ b/plone/namedfile/tests/test_scaling.py
@@ -85,6 +85,22 @@ class ImageScalingTests(unittest.TestCase):
         self.assertEqual(foo.height, 80)
         assertImage(self, foo.data.data, 'PNG', (80, 80))
 
+    def testCreateExactScale(self):
+        foo = self.scaling.scale('image', width=100, height=80)
+        self.assertIsNot(foo.data, self.item.image)
+
+        # test that exact scale without parameters returns original
+        foo = self.scaling.scale('image',
+                                 width=self.item.image._width,
+                                 height=self.item.image._height)
+        self.assertIs(foo.data, self.item.image)
+
+        foo = self.scaling.scale('image',
+                                 width=self.item.image._width,
+                                 height=self.item.image._height,
+                                 quality=80)
+        self.assertIsNot(foo.data, self.item.image)
+
     def testCreateHighPixelDensityScale(self):
         self.scaling.getHighPixelDensityScales = lambda: [{'scale': 2, 'quality': 66}]
         foo = self.scaling.scale('image', width=100, height=80)


### PR DESCRIPTION
Plone REST API use cases require cacheable unique URL also for the original version of the image 1).
Until now, this has caused some performance penalty, created unnecessary blob and actually delivered lower quality copy of the original. Now, if the scaling parameters would result to exact size with the original, with now other parameters (e.g. change in format), no scaling will happen, but the scale URL will return the original blob.

1) https://github.com/plone/plone.restapi/commit/dd0ca2542ddc4ef868b78d89789711777ff94076&