### PR TITLE
Split DefaultImageScalingFactory into more methods for flexibility

### DIFF
--- a/news/104.feature
+++ b/news/104.feature
@@ -1,2 +1,2 @@
-Add support for tiles in DefaultImageScalingFactory.
+Make DefaultImageScalingFactory more flexible, with methods you can override.
 [maurits]

--- a/news/104.feature
+++ b/news/104.feature
@@ -1,0 +1,2 @@
+Add support for tiles in DefaultImageScalingFactory.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 import os
 
 
-version = '5.5.2.dev0'
+version = '5.6.0.dev0'
 
 description = 'File types and fields for images, files and blob files with ' \
               'filenames'


### PR DESCRIPTION
plone.app.tiles has its [own image scale factory](https://github.com/plone/plone.app.tiles/blob/3.2.2/plone/app/tiles/imagescaling.py#L110).
It [passes this around](https://github.com/plone/plone.app.tiles/blob/3.2.2/plone/app/tiles/imagescaling.py#L180) in a [deprecated way](https://github.com/plone/plone.scale/blob/3.1.2/plone/scale/storage.py#L207-L212).
Its scale factory does almost the same as the DefaultImageScalingFactory, although it is structured differently, as a function instead of a class.
Result is that the tiles scale factory is missing some features and fixes from the default, at least support for SVG and passing a quality parameter.

The only *intended* difference of the tile scale factory, is that it gets the original field value from the [tile data](https://github.com/plone/plone.app.tiles/blob/3.2.2/plone/app/tiles/imagescaling.py#L114),
instead of a [field on the context](https://github.com/plone/plone.namedfile/blob/5.5.1/plone/namedfile/scaling.py#L214).

The current commit makes the DefaultImageScalingFactory work for tiles.
Next step would be to update plone.app.tiles to use this.  This mostly involves removing code.

(Maybe something similar would be useful/needed for images in portlets, but I did not check. Do scales of images fields in portlets even work today?)

This will also make future support for focal points easier: there will be just one scaling factory to fix, instead of two.

For me it would be fine to include this in Plone 5.2: I am using this code in a client project on 5.2, and it is working fine. But I am biased. Also fine to do this in 6.0 only.