### PR TITLE
Register AnnotationStorage as IImageScaleStorage multi adapter.

### DIFF
--- a/news/44.feature
+++ b/news/44.feature
@@ -1,0 +1,4 @@
+Register ``AnnotationStorage`` as ``IImageScaleStorage`` multi adapter.
+Both from ``plone.scale``.
+Use this adapter in our scaling functions when we store or get an image scale.
+[maurits]

--- a/plone/namedfile/scaling.zcml
+++ b/plone/namedfile/scaling.zcml
@@ -22,6 +22,13 @@
       factory=".scaling.DefaultImageScalingFactory"
       for="*"
   />
+  <!-- For the storage, we adapt a context
+       and an optional modified callable. -->
+  <adapter
+      factory="plone.scale.storage.AnnotationStorage"
+      provides="plone.scale.storage.IImageScaleStorage"
+      for="* *"
+  />
 
   <!-- In plone.app.caching, image scales are weakly cached.
        But stable (uid) image scales should be strongly cached.


### PR DESCRIPTION
Both from `plone.scale`.
Use this adapter in our scaling functions when we store or get an image scale.
See https://github.com/plone/plone.scale/issues/44

Having it as a multi adapter for context and an optional 'modified' function feels a but clunky, but that is how the `AnnotationStorage` is defined, and I could not get it to work otherwise.

Might be good to add some tests, so let me make this a WIP for now. But it seems to work.