### PR TITLE
ImageScaling view: use guarded_orig_image to get field from a url.

### DIFF
--- a/news/104.bugfix
+++ b/news/104.bugfix
@@ -1,0 +1,3 @@
+``ImageScaling`` view: use ``guarded_orig_image`` to get field from a url.
+Mostly, this makes the view easier to customize.
+[maurits]

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -380,7 +380,7 @@ class ImageScaling(BrowserView):
             # otherwise `name` must refer to a field...
             if "." in name:
                 name, ext = name.rsplit(".", 1)
-            value = getattr(self.context, name)
+            value = self.guarded_orig_image(name)
             scale_view = self._scale_view_class(
                 self.context, self.request, data=value, fieldname=name,
             )


### PR DESCRIPTION
Mostly, this makes the view easier to customize.
I want to use this in https://github.com/plone/plone.app.tiles/pull/50.
`plone.app.tiles` would no longer need to override the `publishTraverse` method then.