### PR TITLE
Only look at width when checking if HiDPI image would be too large

### DIFF
--- a/news/114.bugfix
+++ b/news/114.bugfix
@@ -1,0 +1,3 @@
+Only look at the width when checking if a HiDPI image would be larger than the original.
+Otherwise HiDPI srcsets are never included when the scale is defined with a height of 65536.
+[maurits]

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -538,9 +538,8 @@ class ImageScaling(BrowserView):
         (orig_width, orig_height) = self.getImageSize(fieldname)
         for hdScale in self.getHighPixelDensityScales():
             # Don't create retina scales larger than the source image.
-            if (height and orig_height and orig_height < height * hdScale["scale"]) or (
-                width and orig_width and orig_width < width * hdScale["scale"]
-            ):
+            # We only care about the width, because height might be 65536.
+            if width and orig_width and orig_width < width * hdScale["scale"]:
                 continue
             parameters["quality"] = hdScale["quality"]
             scale_src = storage.scale(


### PR DESCRIPTION
Otherwise HiDPI srcsets are never included when the scale is defined with a height of 65536.
Fixes https://github.com/plone/plone.namedfile/issues/114

This is similar to https://github.com/plone/plone.scale/issues/53