### PR TITLE
Fix CI: libvcs 0.12 fails for us.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ commands_pre =
 
 [testenv:plone60-py{37,38,39,310}]
 commands_pre =
-    pip install mxdev
+    pip install -U pip
+    # for libvcs pin, see https://github.com/bluedynamics/mxdev/issues/10
+    pip install mxdev "libvcs<0.12"
     mxdev -c sources-60.ini
-    pip install --use-deprecated legacy-resolver -rrequirements-60-mxdev.txt
+    pip install -rrequirements-60-mxdev.txt


### PR DESCRIPTION
I made this branch two weeks ago but forgot about it. I probably hoped for a quicker fix in `mxdev`. The fix is coming, but we need this PR for now.

Only pulled in on Python 3.9+.
See https://github.com/bluedynamics/mxdev/issues/10
No longer use the deprecated legacy resolver on Plone 6, upgrade to pip 22.