### PR TITLE
a bit of performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ develop-eggs
 include
 lib
 parts
+pyvenv.cfg
 requirements-*-mxdev.txt

--- a/news/177.feature.1
+++ b/news/177.feature.1
@@ -1,0 +1,2 @@
+removed marking request for disable CSRF protection (need plone.scale with https://github.com/plone/plone.scale/pull/58)
+[mamico]

--- a/news/177.feature.2
+++ b/news/177.feature.2
@@ -1,0 +1,2 @@
+use the attribute _sizes for local caching correctly available_sizes
+[mamico]

--- a/news/177.feature.3
+++ b/news/177.feature.3
@@ -1,0 +1,2 @@
+add additional infos in scale storage only if missing
+[mamico]

--- a/plone/namedfile/__init__.py
+++ b/plone/namedfile/__init__.py
@@ -4,27 +4,3 @@ from plone.namedfile.file import NamedBlobImage  # noqa
 from plone.namedfile.file import NamedFile  # noqa
 from plone.namedfile.file import NamedImage  # noqa
 
-
-# XXX: this is a temporary monkey patch for testing 
-# https://github.com/plone/plone.namedfile/pull/117
-from plone.scale.storage import AnnotationStorage
-from zope.annotation import IAnnotations
-from plone.scale.storage import  ScalesDict
-from plone.protect.auto import safeWrite
-
-
-def _storage(self):
-    annotations = IAnnotations(self.context)
-    if "plone.scale" not in annotations:
-        annotations["plone.scale"] = ScalesDict()
-        safeWrite(self.context)
-    scales = annotations["plone.scale"]
-    if not isinstance(scales, ScalesDict):
-        # migrate from PersistentDict to ScalesDict
-        new_scales = ScalesDict(scales)
-        annotations["plone.scale"] = new_scales
-        safeWrite(self.context)
-        return new_scales
-    return scales
-
-AnnotationStorage.storage = property(_storage)

--- a/plone/namedfile/__init__.py
+++ b/plone/namedfile/__init__.py
@@ -3,3 +3,28 @@ from plone.namedfile.file import NamedBlobFile  # noqa
 from plone.namedfile.file import NamedBlobImage  # noqa
 from plone.namedfile.file import NamedFile  # noqa
 from plone.namedfile.file import NamedImage  # noqa
+
+
+# XXX: this is a temporary monkey patch for testing 
+# https://github.com/plone/plone.namedfile/pull/117
+from plone.scale.storage import AnnotationStorage
+from zope.annotation import IAnnotations
+from plone.scale.storage import  ScalesDict
+from plone.protect.auto import safeWrite
+
+
+def _storage(self):
+    annotations = IAnnotations(self.context)
+    if "plone.scale" not in annotations:
+        annotations["plone.scale"] = ScalesDict()
+        safeWrite(self.context)
+    scales = annotations["plone.scale"]
+    if not isinstance(scales, ScalesDict):
+        # migrate from PersistentDict to ScalesDict
+        new_scales = ScalesDict(scales)
+        annotations["plone.scale"] = new_scales
+        safeWrite(self.context)
+        return new_scales
+    return scales
+
+AnnotationStorage.storage = property(_storage)

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -10,7 +10,6 @@ from plone.namedfile.interfaces import IStableImageScale
 from plone.namedfile.utils import getHighPixelDensityScales
 from plone.namedfile.utils import set_headers
 from plone.namedfile.utils import stream_data
-from plone.protect.utils import safeWrite
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from plone.scale.interfaces import IImageScaleFactory
 from plone.scale.interfaces import IScaledImageQuality
@@ -520,8 +519,6 @@ class ImageScaling(BrowserView):
             )
         if "fieldname" not in info:
             info["fieldname"] = fieldname
-        if self.request is not None:
-            safeWrite(info, self.request)
         scale_view = self._scale_view_class(self.context, self.request, **info)
         return scale_view
 

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -418,8 +418,7 @@ class ImageScaling(BrowserView):
         if self._sizes is None:
             sizes_util = queryUtility(IAvailableSizes)
             if sizes_util is None:
-                if self._sizes is None:
-                    self._sizes = {}
+                self._sizes = {}
             else:
                 self._sizes = sizes_util() or {}
         return self._sizes

--- a/plone/namedfile/tests/test_scaling.py
+++ b/plone/namedfile/tests/test_scaling.py
@@ -387,10 +387,11 @@ class ImageScalingTests(unittest.TestCase):
         self.assertEqual(foo.width, 42)
         self.assertEqual(foo.height, 42)
 
-    def testAvailableSizes(self):
+    def testDefaultAvailableSizes(self):
         # by default, no named scales are configured
         self.assertEqual(self.scaling.available_sizes, {})
 
+    def testCustomAvailableSizes(self):
         # a callable can be used to look up the available sizes
         def custom_available_sizes():
             return {'bar': (10, 10)}


### PR DESCRIPTION
1. removed marking request for disable CSRF protection (scalesdict are already "safe type" for plone.protect)
2. use the attribute _sizes for local caching correctly available_sizes
3. add additional infos in scale storage only if missing (probably could be better to move writes in plone.scale)

Tested against a @querystring-search restapi that returns fullobjects with leadimage:
before 0.12289s, with these changes 0.06316s (b_size=10) and from 2.02214s to 0.97613s (b_size=200)

