### PR TITLE
Get title from ImageScale class.

### DIFF
--- a/news/128.bugfix
+++ b/news/128.bugfix
@@ -1,0 +1,4 @@
+Get title from ImageScale class.
+Prevents a traceback when the context is a tile.
+When no title can we found, fall back to an empty string.
+[maurits]

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -107,6 +107,24 @@ class ImageScale(BrowserView):
         srcset_attr = ", ".join(_srcset_attr)
         return srcset_attr
 
+    @property
+    def title(self):
+        """Get the title from the context.
+
+        Let's not fail when we cannot find a title.
+        """
+        try:
+            # Most Plone content items.
+            return self.context.Title()
+        except AttributeError:
+            pass
+        try:
+            # Can work on a tile and most other things.
+            return self.context.title
+        except AttributeError:
+            pass
+        return ""
+
     def tag(
         self,
         height=_marker,
@@ -123,9 +141,9 @@ class ImageScale(BrowserView):
             width = getattr(self, "width", self.data._width)
 
         if alt is _marker:
-            alt = self.context.Title()
+            alt = self.title
         if title is _marker:
-            title = self.context.Title()
+            title = self.title
 
         values = [
             ("src", self.url),

--- a/plone/namedfile/tests/test_scaling.py
+++ b/plone/namedfile/tests/test_scaling.py
@@ -6,6 +6,7 @@ from plone.namedfile.field import NamedImage as NamedImageField
 from plone.namedfile.file import NamedImage
 from plone.namedfile.interfaces import IAvailableSizes
 from plone.namedfile.interfaces import IImageScaleTraversable
+from plone.namedfile.scaling import ImageScale
 from plone.namedfile.scaling import ImageScaling
 from plone.namedfile.testing import PLONE_NAMEDFILE_FUNCTIONAL_TESTING
 from plone.namedfile.testing import PLONE_NAMEDFILE_INTEGRATION_TESTING
@@ -294,6 +295,13 @@ class FakeImageScaleStorage:
         for value in self.storage.values():
             if value["key"] == hash:
                 return value
+
+
+class TitleImageScale(ImageScale):
+    """ImageScale class with its own title property.
+    """
+
+    title = "title from class"
 
 
 # @patch.multiple(
@@ -925,6 +933,28 @@ class StorageTests(unittest.TestCase):
         self.assertEqual(scale_uid.data.uid, "uid-0")
         self.assertEqual(scale_uid.data.info["uid"], "uid-0")
         self.assertIs(scale_uid.data, scale2.data)
+
+    def test_title(self):
+        # Test that a custom title property on an ImageScale class is used.
+        item = FakeImage("abcdef", "jpeg")
+        scaling = ImageScaling(item, None)
+        scaling._scale_view_class = TitleImageScale
+        self.assertEqual(
+            scaling.tag("image"),
+            '<img src="http://fake.image/@@images/image.jpeg" alt="title from class" title="title from class" height="4" width="6" />'
+        )
+        self.assertEqual(
+            scaling.tag("image", alt="own alt"),
+            '<img src="http://fake.image/@@images/image.jpeg" alt="own alt" title="title from class" height="4" width="6" />'
+        )
+        self.assertEqual(
+            scaling.tag("image", title="own title"),
+            '<img src="http://fake.image/@@images/image.jpeg" alt="title from class" title="own title" height="4" width="6" />'
+        )
+        self.assertEqual(
+            scaling.tag("image", alt="own alt", title="own title"),
+            '<img src="http://fake.image/@@images/image.jpeg" alt="own alt" title="own title" height="4" width="6" />'
+        )
 
 
 def test_suite():


### PR DESCRIPTION
Prevents a traceback:

```
  File "/Users/maurits/clients/zeelandia/plone60/var/cache/e7f22b3d94223db6a4dc52ff402b3a33.py", line 184, in render
    __value = _static_4510349056('python',

    "scale.scale('image', scale='large').tag(css_class='img-responsive', alt='Alt')",

    econtext=econtext)(_static_4510348768(econtext, __zt_tmp))
  File "/Users/maurits/shared-eggs/cp39/zope.tales-5.1-py3.9.egg/zope/tales/pythonexpr.py", line 73, in __call__
    return eval(self._code, vars)
  File "<string>", line 1, in <module>
File "/Users/maurits/clients/zeelandia/plone60/develop/plone.namedfile/plone/namedfile/scaling.py", line 128, in tag
    title = self.context.Title()
AttributeError: 'SimpleViewClass from /Users/maurits/clients/zeelan' object has no attribute 'Title'
```

This is when generating a tag and you do not pass an explicit `alt` and `title`.
You could override this in special cases, but we try the following now, which should fit most use cases:

- First try `self.context.Title()` like before. This should work on all content items.
- Then try `self.context.title`, which may work for tiles with a title field, and also for most other items.
- Fall back to an empty string. I think most people prefer an empty alt or title instead of a missing image tag, or an error rendering the tile.