### PR TITLE
Use mode parameter instead of deprecated direction

### DIFF
--- a/news/102.bugfix
+++ b/news/102.bugfix
@@ -1,0 +1,2 @@
+Use ``mode`` parameter instead of deprecated ``direction`` and warn user about it.
+[petschki, maurits]

--- a/plone/namedfile/adapters.py
+++ b/plone/namedfile/adapters.py
@@ -121,7 +121,6 @@ class ImageFieldScales:
             fieldname,
             width=width,
             height=height,
-            direction="thumbnail",
             pre=True,
             include_srcset=False,
         )

--- a/plone/namedfile/test.pt
+++ b/plone/namedfile/test.pt
@@ -69,7 +69,7 @@
   </section>
   <hr />
   <section id="examples">
-    <h2>Examples with direction/mode</h2>
+    <h2>Examples with mode</h2>
 
     <h3>Mini</h3>
     <figure class="figure"
@@ -78,16 +78,16 @@
       <br /><code tal:content="img_tag" />
     </figure>
 
-    <h3 id="cover">Mini direction=cover</h3>
+    <h3 id="cover">Mini mode=cover</h3>
     <figure class="figure"
-      tal:define="img_tag python:images.tag('image', scale='mini', direction='cover')">
+      tal:define="img_tag python:images.tag('image', scale='mini', mode='cover')">
       <img tal:replace="structure img_tag" />
       <br /><code tal:content="img_tag" />
     </figure>
 
-    <h3 id="contain">Mini direction=contain</h3>
+    <h3 id="contain">Mini mode=contain</h3>
     <figure class="figure"
-      tal:define="img_tag python:images.tag('image', scale='mini', direction='contain')">
+      tal:define="img_tag python:images.tag('image', scale='mini', mode='contain')">
       <img tal:replace="structure img_tag" />
       <br /><code tal:content="img_tag" />
     </figure>
@@ -96,9 +96,7 @@
   <section id="picture">
     <h2>Picture tags</h2>
     <p>
-      Temporary note:
-      Picture tags only work on Plone 6, with several other branches merged.
-      See <a href="https://github.com/plone/buildout.coredev/blob/6.0/plips/plip-image-srcsets.cfg">coredev</a>.
+      Picture tags only work on Plone 6.
       If not available (like on Plone 5.2), an ordinary image tag is created.
     </p>
 

--- a/plone/namedfile/tests/test_adapters.py
+++ b/plone/namedfile/tests/test_adapters.py
@@ -85,7 +85,7 @@ class ImageScalesAdaptersRegisteredTest(unittest.TestCase):
             },
         )
         # Note: self.content.absolute_url() is actually empty in this test.
-        self.assertTrue(download.startswith(f"@@images/image1-16-"))
+        self.assertTrue(download.startswith("@@images/image1-16-"))
         self.assertTrue(download.endswith(".gif"))
         self.assertIn("listing", scales)
         self.assertEqual(len(scales), 1)
@@ -94,7 +94,7 @@ class ImageScalesAdaptersRegisteredTest(unittest.TestCase):
         self.assertEqual(listing["height"], 16)
         self.assertEqual(listing["width"], 16)
         download = listing["download"]
-        self.assertTrue(download.startswith(f"@@images/image1-16-"))
+        self.assertTrue(download.startswith("@@images/image1-16-"))
         self.assertTrue(download.endswith(".gif"))
 
     @unittest.skipIf(IImageScalesFieldAdapter is not None, "Skipping on Plone 6")
@@ -131,7 +131,7 @@ class ImageScalesAdaptersRegisteredTest(unittest.TestCase):
             },
         )
         # Note: self.content.absolute_url() is actually empty in this test.
-        self.assertTrue(download.startswith(f"@@images/image1-900-"))
+        self.assertTrue(download.startswith("@@images/image1-900-"))
         self.assertTrue(download.endswith(".jpeg"))
         # larger and huge should not be in here: these scales would return the same
         # content as the original.
@@ -142,4 +142,4 @@ class ImageScalesAdaptersRegisteredTest(unittest.TestCase):
         preview = scales["preview"]
         self.assertEqual(preview["width"], 400)
         self.assertEqual(preview["height"], 400)
-        self.assertTrue(preview["download"].startswith(f"@@images/image1-400-"))
+        self.assertTrue(preview["download"].startswith("@@images/image1-400-"))

--- a/plone/namedfile/tests/test_scaling.py
+++ b/plone/namedfile/tests/test_scaling.py
@@ -30,6 +30,7 @@ import plone.namedfile.scaling
 import re
 import time
 import unittest
+import warnings
 
 
 # Unique scale name used to be a uuid.uui4(),
@@ -672,7 +673,29 @@ http://nohost/item/@@images/image-1200-....png 1200w"/>
 
     def testGetAvailableSizes(self):
         self.scaling.available_sizes = {"foo": (60, 60)}
-        assert self.scaling.getAvailableSizes("image") == {"foo": (60, 60)}
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("once")
+            self.assertEqual(
+                self.scaling.getAvailableSizes(),
+                {"foo": (60, 60)},
+            )
+            self.assertEqual(len(w), 1)
+            self.assertIs(w[0].category, DeprecationWarning)
+            self.assertIn(
+                "use property available_sizes instead",
+                str(w[0].message),
+            )
+            self.assertEqual(
+                self.scaling.getAvailableSizes("image"),
+                {"foo": (60, 60)},
+            )
+            self.assertEqual(len(w), 2)
+            self.assertIs(w[1].category, DeprecationWarning)
+            self.assertIn(
+                "fieldname was passed to deprecated getAvailableSizes, but "
+                "will be ignored.",
+                str(w[1].message),
+            )
 
     def testGetImageSize(self):
         assert self.scaling.getImageSize("image") == (200, 200)

--- a/plone/namedfile/usage.rst
+++ b/plone/namedfile/usage.rst
@@ -357,8 +357,8 @@ several ways that you may reference scales from page templates.
 
 1. for full control you may do the tag generation explicitly::
 
-     <img tal:define="scales context/@@images;
-                      thumbnail python: scales.scale('image', width=64, height=64);"
+     <img tal:define="images context/@@images;
+                      thumbnail python: images.scale('image', width=64, height=64);"
           tal:condition="thumbnail"
           tal:attributes="src thumbnail/url;
                           width thumbnail/width;
@@ -366,16 +366,16 @@ several ways that you may reference scales from page templates.
 
    This would create an up to 64 by 64 pixel scaled down version of the image
    stored in the "image" field.  It also allows for passing in additional
-   parameters support by `plone.scale`_'s ``scaleImage`` function, e.g.
-   ``direction`` or ``quality``.
+   parameters supported by the ``scaleImage`` function from ``plone.scale``,
+   e.g. ``mode`` or ``quality``.
 
-   .. _`plone.scale`: http://pypi.python.org/pypi/plone.scale
+   .. _`plone.scale`: https://pypi.org/project/plone.scale/
 
 2. for automatic tag generation with extra parameters you would use::
 
-     <img tal:define="scale context/@@images"
-          tal:replace="structure python: scale.scale('image',
-                       width=1200, height=800, direction='down').tag()" />
+     <img tal:define="images context/@@images"
+          tal:replace="structure python: images.tag('image',
+                       width=1200, height=800, mode='contain')" />
 
 3. It is possible to access scales via predefined named scale sizes, rather
    than hardcoding the dimensions every time you access a scale.  The scale
@@ -384,9 +384,8 @@ several ways that you may reference scales from page templates.
    scale name => (width, height).  A scale called 'mini' could then be accessed
    like this::
 
-     <img tal:define="scale context/@@images"
-          tal:replace="structure python: scale.scale('image',
-                       scale='mini').tag()" />
+     <img tal:define="images context/@@images"
+          tal:replace="structure python: images.tag('image', scale='mini')" />
 
    This would use the predefined scale size "mini" to determine the desired
    image dimensions, but still allow to pass in extra parameters.


### PR DESCRIPTION
Fixes https://github.com/plone/plone.namedfile/issues/102

I noticed that `test.pt` still used the deprecated `direction='contain'`. It _did_ work, turning a landscape image into a square:

<img width="779" alt="Screenshot 2022-08-12 at 14 16 42" src="https://user-images.githubusercontent.com/210587/184387398-2bd6edc8-e2e9-44cf-ac2d-c1aa56d4cfa5.png">

With the newer `mode="contain"` the result would not have been so good, basically ignoring the setting:

<img width="775" alt="Screenshot 2022-08-12 at 14 17 01" src="https://user-images.githubusercontent.com/210587/184387550-f26874f7-f625-46b9-921e-eefe7bf22a22.png">

With this PR, the newer spelling works too.