### PR TITLE
move getAllowedSizes + getQuality from CMFPlone.utils to here

### DIFF
--- a/news/132.bugfix
+++ b/news/132.bugfix
@@ -1,0 +1,2 @@
+Move getAllowedSizes + getQuality from CMFPlone.utils to this package.
+[jensens]

--- a/plone/namedfile/configure.zcml
+++ b/plone/namedfile/configure.zcml
@@ -27,4 +27,18 @@
   <!-- This adapter is only needed and used on Plone 6.  -->
   <adapter zcml:condition="installed plone.base" factory=".adapters.ImageFieldScales" />
 
+  <!-- configure sizes lookup for IAvailableSizes -->
+  <utility
+      zcml:condition="have plone-60"
+      component=".utils.getAllowedSizes"
+      provides=".interfaces.IAvailableSizes"
+      />
+
+  <!-- quality lookup for IScaledImageQuality from plone.scale, which itself has no ZCML-->
+  <utility
+      zcml:condition="have plone-60"
+      component=".utils.getQuality"
+      provides="plone.scale.interfaces.IScaledImageQuality"
+      />
+
 </configure>

--- a/plone/namedfile/utils/__init__.py
+++ b/plone/namedfile/utils/__init__.py
@@ -337,3 +337,30 @@ def getHighPixelDensityScales():
             {"scale": 3, "quality": settings.quality_3x},
         ]
     return []
+
+def getAllowedSizes():
+    registry = queryUtility(IRegistry)
+    if not registry:
+        return None
+    settings = registry.forInterface(
+        IImagingSchema, prefix="plone", check=False)
+    if not settings.allowed_sizes:
+        return None
+    sizes = {}
+    for line in settings.allowed_sizes:
+        line = line.strip()
+        if line:
+            name, width, height = pattern.match(line).groups()
+            name = name.strip().replace(' ', '_')
+            sizes[name] = int(width), int(height)
+    return sizes
+
+
+def getQuality():
+    registry = queryUtility(IRegistry)
+    if registry:
+        settings = registry.forInterface(
+            IImagingSchema, prefix="plone", check=False)
+        return settings.quality or QUALITY_DEFAULT
+    return QUALITY_DEFAULT
+

--- a/plone/namedfile/utils/__init__.py
+++ b/plone/namedfile/utils/__init__.py
@@ -17,8 +17,12 @@ import mimetypes
 import os.path
 import piexif
 import PIL.Image
+import re
 import struct
 
+# image-scaling
+QUALITY_DEFAULT = 88
+pattern = re.compile(r'^(.*)\s+(\d+)\s*:\s*(\d+)$')
 
 log = getLogger(__name__)
 


### PR DESCRIPTION
rationale: untangle circular dependencies in pa.vocabularies, put things where they belong to.
Do its ZCML registration conditional, as it seems the package might still work on 5.2

Needs to be merged with PR in Products.CMFPlone (tbd)