### PR TITLE
Tox: explicitly test only the plone.namedfile package.

### DIFF
--- a/news/50.tests
+++ b/news/50.tests
@@ -1,0 +1,1 @@
+Tox: explicitly test only the ``plone.namedfile`` package.  [maurits]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,18 @@ showcontent = true
 directory = "bugfix"
 name = "Bug fixes:"
 showcontent = true
+
+[[tool.towncrier.type]]
+directory = "internal"
+name = "Internal:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "documentation"
+name = "Documentation:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "tests"
+name = "Tests"
+showcontent = true

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ skip_install = true
 commands =
     python -V
     pip list
-    zope-testrunner --test-path={toxinidir} {posargs:-vc}
+    zope-testrunner --test-path={toxinidir} -s plone.namedfile {posargs:-vc}
 
 [testenv:plone52-py{37,38}]
 commands_pre =


### PR DESCRIPTION
Otherwise tests in source checkouts may be found as well.