### PR TITLE
Break dependency cycle

### DIFF
--- a/news/3764.internal
+++ b/news/3764.internal
@@ -1,0 +1,3 @@
+Move code from plone.app.z3cform here here
+to break a cyclic dependency.
+[gforcada]

--- a/plone/namedfile/storages.py
+++ b/plone/namedfile/storages.py
@@ -105,3 +105,14 @@ class PDataStorable:
         fp = blob.open("w")
         fp.write(bytes(pdata))
         fp.close()
+
+
+@implementer(IStorage)
+class Zope2FileUploadStorable:
+    def store(self, data, blob):
+        data.seek(0)
+        with blob.open("w") as fp:
+            block = data.read(MAXCHUNKSIZE)
+            while block:
+                fp.write(block)
+                block = data.read(MAXCHUNKSIZE)

--- a/plone/namedfile/z3c-blobfile.zcml
+++ b/plone/namedfile/z3c-blobfile.zcml
@@ -56,6 +56,12 @@
       factory=".storages.PDataStorable"
       />
 
+  <utility
+      factory=".storages.Zope2FileUploadStorable"
+      provides=".interfaces.IStorage"
+      name="ZPublisher.HTTPRequest.FileUpload"
+      />
+
   <adapter factory=".copy.BlobFileCopyHook" />
 
 </configure>


### PR DESCRIPTION
Part of https://github.com/plone/Products.CMFPlone/issues/3764

@jensens [you moved that code](https://github.com/plone/plone.app.z3cform/commits/master/plone/app/z3cform/factories.py) from `plone.app.widgets` to `plone.app.z3cform`.

Would you agree on moving the code again to `plone.namedfile` ? 🤔 

The utility itself is completely related to `plone.namedfile` so it _feels_ that it make sense to move it here.

If we agree to merge this, we need a corresponding PR on `plone.app.z3cform` to deprecate that code 🧹 