### PR TITLE
Fix picture tag when original image is used instead of a scale.

### DIFF
--- a/news/142.bugfix
+++ b/news/142.bugfix
@@ -1,0 +1,2 @@
+Fix picture tag when original image is used instead of a scale.
+[maurits]

--- a/plone/namedfile/picture.py
+++ b/plone/namedfile/picture.py
@@ -145,5 +145,15 @@ class Img2PictureTag:
             src_scale = "/".join(parts[:-1]) + f"/{field_name}/{scale}"
             src_scale
         else:
-            src_scale = "/".join(parts[:-1]) + f"/{scale}"
+            # Usually the url has '@@images/fieldname/other_scale',
+            # and then we replace the other scale.
+            # But the url may use the original image, e.g. @@images/image.
+            # Then we want to keep the fieldname and return '.../image/scale'.
+            try:
+                full = len(parts) - parts.index("@@images") == 2
+            except ValueError:
+                full = False
+            if not full:
+                parts = parts[:-1]
+            src_scale = "/".join(parts) + f"/{scale}"
         return src_scale

--- a/plone/namedfile/tests/test_scaling.py
+++ b/plone/namedfile/tests/test_scaling.py
@@ -980,6 +980,34 @@ class StorageTests(unittest.TestCase):
         )
 
 
+class Img2PictureTagTests(unittest.TestCase):
+    """Low level tests for Img2PictureTag."""
+
+    def _makeOne(self):
+        return plone.namedfile.picture.Img2PictureTag()
+
+    def test_update_src_scale(self):
+        update_src_scale = self._makeOne().update_src_scale
+        self.assertEqual(
+            update_src_scale("foo/fieldname/old", "new"),
+            "foo/fieldname/new"
+        )
+        self.assertEqual(
+            update_src_scale("@@images/fieldname/old", "mini"),
+            "@@images/fieldname/mini"
+        )
+        self.assertEqual(
+            update_src_scale("@@images/fieldname", "preview"),
+            "@@images/fieldname/preview"
+        )
+        self.assertEqual(
+            update_src_scale(
+                "photo.jpg/@@images/image-1200-4a03b0a8227d28737f5d9e3e481bdbd6.jpeg",
+                "teaser"),
+            "photo.jpg/@@images/image/teaser",
+        )
+
+
 def test_suite():
     from unittest import defaultTestLoader
 


### PR DESCRIPTION
Fixes https://github.com/plone/plone.namedfile/issues/142