### PR TITLE
Add internal modification timestamp.

### DIFF
--- a/news/149.internal
+++ b/news/149.internal
@@ -1,0 +1,2 @@
+Add internal modification timestamp with fallback to _p_mtime.
+[mathias.leimgruber]

--- a/plone/namedfile/file.py
+++ b/plone/namedfile/file.py
@@ -1,6 +1,7 @@
 # The implementations in this file are largely borrowed
 # from zope.app.file and z3c.blobfile
 # and are licensed under the ZPL.
+from DateTime import DateTime
 from logging import getLogger
 from persistent import Persistent
 from plone.namedfile.interfaces import INamedBlobFile
@@ -70,8 +71,17 @@ except ImportError:
     pass
 
 
+class ModifiedPropertyMixin:
+    @property
+    def modified(self):
+        if hasattr(self, "_modified"):
+            return self._modified
+        # Fall back to modification time in database.
+        return self._p_mtime
+
+
 @implementer(INamedFile)
-class NamedFile(Persistent):
+class NamedFile(Persistent, ModifiedPropertyMixin):
     """A non-BLOB file that stores a filename
 
     Let's test the constructor:
@@ -169,6 +179,7 @@ class NamedFile(Persistent):
         self.data = data
         self.contentType = contentType
         self.filename = filename
+        self._modified = DateTime().millis()
 
     def _getData(self):
         if isinstance(self._data, tuple(FILECHUNK_CLASSES)):
@@ -177,6 +188,7 @@ class NamedFile(Persistent):
             return self._data
 
     def _setData(self, data):
+        self._modified = DateTime().millis()
 
         # Handle case when data is a string
         if isinstance(data, str):
@@ -310,7 +322,7 @@ class NamedImage(NamedFile):
 
 
 @implementer(INamedBlobFile, HTTPRangeSupport.HTTPRangeInterface)
-class NamedBlobFile(Persistent):
+class NamedBlobFile(Persistent, ModifiedPropertyMixin):
     """A file stored in a ZODB BLOB, with a filename"""
 
     filename = FieldProperty(INamedFile["filename"])
@@ -325,6 +337,7 @@ class NamedBlobFile(Persistent):
         f.close()
         self._setData(data)
         self.filename = filename
+        self._modified = DateTime().millis()
 
     def open(self, mode="r"):
         if mode != "r" and "size" in self.__dict__:
@@ -342,6 +355,7 @@ class NamedBlobFile(Persistent):
         log.debug("Storage selected for data: %s", dottedName)
         storable = getUtility(IStorage, name=dottedName)
         storable.store(data, self._blob)
+        self._modified = DateTime().millis()
 
     def _getData(self):
         fp = self._blob.open("r")

--- a/plone/namedfile/tests/__init__.py
+++ b/plone/namedfile/tests/__init__.py
@@ -1,3 +1,8 @@
+from DateTime import DateTime
+from plone.namedfile.file import NamedBlobImage
+from plone.namedfile.file import NamedImage
+
+
 import os
 
 
@@ -6,3 +11,11 @@ def getFile(filename, length=None):
     filename = os.path.join(os.path.dirname(__file__), filename)
     with open(filename, "rb") as data_file:
         return data_file.read(length)
+
+
+class MockNamedImage(NamedImage):
+    _p_mtime = DateTime().millis()
+
+
+class MockNamedBlobImage(NamedBlobImage):
+    _p_mtime = DateTime().millis()

--- a/plone/namedfile/tests/test_image.py
+++ b/plone/namedfile/tests/test_image.py
@@ -1,12 +1,15 @@
 # This file is borrowed from zope.app.file and licensed ZPL.
 
+from DateTime import DateTime
 from plone.namedfile.file import NamedImage
 from plone.namedfile.interfaces import INamedImage
 from plone.namedfile.testing import PLONE_NAMEDFILE_INTEGRATION_TESTING
 from plone.namedfile.tests import getFile
+from plone.namedfile.tests import MockNamedImage
 from plone.namedfile.utils import get_contenttype
 from zope.interface.verify import verifyClass
 
+import time
 import unittest
 
 
@@ -39,15 +42,16 @@ class TestImage(unittest.TestCase):
         file_img = self._makeImage()
         self.assertEqual(file_img.contentType, "")
         self.assertEqual(bytes(file_img.data), b"")
+        self.assertIsNotNone(file_img.modified)
 
     def testConstructor(self):
         file_img = self._makeImage(b"Data")
         self.assertEqual(file_img.contentType, "")
         self.assertEqual(bytes(file_img.data), b"Data")
+        self.assertIsNotNone(file_img.modified)
 
     def testMutators(self):
         image = self._makeImage()
-
         image.contentType = "image/jpeg"
         self.assertEqual(image.contentType, "image/jpeg")
 
@@ -55,6 +59,24 @@ class TestImage(unittest.TestCase):
         self.assertEqual(image.data, zptlogo)
         self.assertEqual(image.contentType, "image/gif")
         self.assertEqual(image.getImageSize(), (16, 16))
+
+    def testModifiedTimeStamp(self):
+        image = self._makeImage()
+        old_timestamp = image.modified
+        time.sleep(1/1000)  # make sure at least 1ms passes
+        image._setData(zptlogo)
+        self.assertNotEqual(image.modified, old_timestamp)
+
+    def testFallBackToDatabaseModifiedTimeStamp(self):
+        dt = DateTime()
+        image = MockNamedImage()
+        image._p_mtime = dt.millis()
+        image._modified = (dt + 1).millis()
+
+        delattr(image, "_modified")
+        marker = object()
+        self.assertEqual(marker, getattr(image, "_modified", marker))
+        self.assertEqual(dt.millis(), image._p_mtime)
 
     def testInterface(self):
         self.assertTrue(INamedImage.implementedBy(NamedImage))

--- a/plone/namedfile/tests/test_scaling.py
+++ b/plone/namedfile/tests/test_scaling.py
@@ -11,6 +11,7 @@ from plone.namedfile.scaling import ImageScaling
 from plone.namedfile.testing import PLONE_NAMEDFILE_FUNCTIONAL_TESTING
 from plone.namedfile.testing import PLONE_NAMEDFILE_INTEGRATION_TESTING
 from plone.namedfile.tests import getFile
+from plone.namedfile.tests import MockNamedImage
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from plone.scale.interfaces import IScaledImageQuality
 from plone.scale.storage import IImageScaleStorage
@@ -141,10 +142,6 @@ class PrimaryFieldInfo:
     @property
     def value(self):
         return self.field
-
-
-class MockNamedImage(NamedImage):
-    _p_mtime = DateTime().millis()
 
 
 @implementer(IScaledImageQuality)


### PR DESCRIPTION
Fixes #149 


I'll keep using `DateTime().millis()`, since this is what the [current implementation](https://github.com/plone/plone.namedfile/blob/b2dc69f99ee6625baa513ca086bbcb300c1c5e52/plone/namedfile/scaling.py#L520-L531) is using as well