### PR TITLE
Use new internal modification timestamp as part of the hash key for scales.

### DIFF
--- a/news/150.internal
+++ b/news/150.internal
@@ -1,0 +1,2 @@
+Use new internal modification timestamp as part of the hash key for scales.
+[mathias.leimgruber]

--- a/plone/namedfile/scaling.py
+++ b/plone/namedfile/scaling.py
@@ -524,8 +524,8 @@ class ImageScaling(BrowserView):
         context = aq_base(self.context)
         if fieldname is not None:
             field = getattr(context, fieldname, None)
-            field_p_mtime = getattr(field, "_p_mtime", None)
-            date = DateTime(field_p_mtime or context._p_mtime)
+            modified = getattr(field, "modified", None)
+            date = DateTime(modified or context._p_mtime)
         else:
             date = DateTime(context._p_mtime)
         return date.millis()

--- a/plone/namedfile/tests/test_scaling.py
+++ b/plone/namedfile/tests/test_scaling.py
@@ -662,6 +662,17 @@ http://nohost/item/@@images/image-1200-....png 1200w"/>
         self.assertNotEqual(scale1a.data, scale1c.data, "scale not updated?")
         self.assertNotEqual(scale2a.data, scale2c.data, "scale not updated?")
 
+    def testFallBackToDatabaseModifiedTimeStamp(self):
+        dt = self.item.modified()
+        scale_a = self.scaling.scale("image", width=100, height=80)
+
+        delattr(self.item.image, "_modified")
+
+        # Since there is no _modified timestamp, _p_mtime is the fallback.
+        self.item.image._p_mtime = (dt + 1).millis()
+        scale_b = self.scaling.scale("image", width=100, height=80)
+        self.assertNotEqual(scale_a.data, scale_b.data)
+
     def testCustomSizeChange(self):
         # set custom image sizes & view a scale
         self.scaling.available_sizes = {"foo": (23, 23)}
@@ -772,7 +783,7 @@ http://nohost/item/@@images/image-1200-....png 1200w"/>
         data = getFile("image.jpg")
         item = DummyContent()
         item.image = NamedImage(data, "image/png", "image.jpg")
-        item.image.modified = dt.millis()
+        item.image._modified = dt.millis()
         scaling = ImageScaling(item, None)
 
         # scale an image, record its size
@@ -783,7 +794,7 @@ http://nohost/item/@@images/image-1200-....png 1200w"/>
         gsm = getGlobalSiteManager()
         qualitySupplier = DummyQualitySupplier()
         gsm.registerUtility(qualitySupplier.getQuality, IScaledImageQuality)
-        item.image.modified = (dt + 1).millis()
+        item.image._modified = (dt + 1).millis()
         # now scale again
         bar = scaling.scale("image", width=100, height=80)
         size_bar = bar.data.getSize()


### PR DESCRIPTION
Depends on #150
Fixes #151 

This PR changes the "date time" factor for the hash_key generation via the @@images view.

Instead of using `_p_mtime` it uses the new introduces `modified` attribute. 
This gives us greater control over the generated hash_key and how to invalidate it.

For example, since the catalog does the indexing async in a precommit hook, the `_p_mtime` was basically not yet there, or too old. So the catalog always stored the prev. hash_key and not the one from the current image. 

Potential Issue:
Since this change introduces a new hash_key for all images, event if not changed, in theory a lot of image scales have to be generated. 

❓ ~~Question~~❓ : 
~~Either the namefile/namedimage or the @@images view could handle the case, if there is no modified timestamp available and fallback to `_p_mtime`. This way only new and modified images would use the new logic and old ones do not need to touched/migrated.~~
