### PR TITLE
Fix the NamedFile modified property

### DIFF
--- a/news/153.bugfix
+++ b/news/153.bugfix
@@ -1,0 +1,1 @@
+Fix calculation of file modification time. @davisagli

--- a/plone/namedfile/file.py
+++ b/plone/namedfile/file.py
@@ -75,7 +75,7 @@ class ModifiedPropertyMixin:
     @property
     def modified(self):
         if hasattr(self, "_modified"):
-            return self._modified
+            return self._modified / 1000
         # Fall back to modification time in database.
         return self._p_mtime
 

--- a/plone/namedfile/tests/test_blobfile.py
+++ b/plone/namedfile/tests/test_blobfile.py
@@ -81,19 +81,19 @@ class TestImage(unittest.TestCase):
         image = self._makeImage()
         old_timestamp = image.modified
         time.sleep(1/1000)  # make sure at least 1ms passes
+        now = DateTime()
+        self.assertGreater(now, DateTime(old_timestamp))
         image._setData(zptlogo)
         self.assertNotEqual(image.modified, old_timestamp)
 
     def testFallBackToDatabaseModifiedTimeStamp(self):
         dt = DateTime()
         image = MockNamedBlobImage()
-        image._p_mtime = dt.millis()
+        image._p_mtime = int(dt)
         image._modified = (dt + 1).millis()
 
         delattr(image, "_modified")
-        marker = object()
-        self.assertEqual(marker, getattr(image, "_modified", marker))
-        self.assertEqual(dt.millis(), image._p_mtime)
+        self.assertEqual(image.modified, image._p_mtime)
 
     def testInterface(self):
         self.assertTrue(INamedBlobImage.implementedBy(NamedBlobImage))


### PR DESCRIPTION
The `modified` property was added in #149. But it's off by a factor of 1000. This leads to making the wrong decision about when to remove existing image scales.

The return value from the property is used to [construct a DateTime](https://github.com/plone/plone.namedfile/blob/master/plone/namedfile/scaling.py#L566), which interprets a numeric value as seconds.

`self._p_time` is in seconds but `self._modified` is in milliseconds, so needs to be divided by 1000.
