### PR TITLE
Support for allowed content types. (Branch for 5.x)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ See the ``usage.rst`` doctest for more details.
 Source Code
 ===========
 
- Note: This packages is licensed under a *BSD license*. 
+ Note: This package is licensed under a *BSD license*.
  Please do not add dependencies on GPL code!
 
 Contributors please read the document `Process for Plone core's development <https://docs.plone.org/develop/coredev/docs/index.html>`_

--- a/news/157-2.feature
+++ b/news/157-2.feature
@@ -1,0 +1,8 @@
+Improve contenttype detection logic for unregistered but common types.
+
+Change get_contenttype to support common types which are or were not registered
+with IANA, like image/webp or audio/midi.
+
+Note: image/webp is already a IANA registered type and also added by
+Products.MimetypesRegistry.
+[thet]

--- a/news/157.feature
+++ b/news/157.feature
@@ -1,0 +1,7 @@
+Support for allowed media types.
+
+Support to constrain files to specific media types with a "accept" attribute on
+file and image fields, just like the "accept" attribute of the HTML file input.
+
+Fixes: #157
+[thet]

--- a/plone/namedfile/field.py
+++ b/plone/namedfile/field.py
@@ -57,7 +57,7 @@ class BinaryContenttypeValidator:
         for accept in self.field.accept:
             if accept[0] == ".":
                 # This is a file extension. Get a media type from it.
-                accept = mimetypes.guess_type(f"dummy{accept}", strict=False)[0]
+                accept = mimetypes.guess_type("dummy" + accept, strict=False)[0]
                 if accept is None:
                     # This extension is unknown. Skip it.
                     continue
@@ -98,10 +98,10 @@ class NamedField(Object):
             self.accept = kw.pop("accept")
         if "schema" in kw:
             self.schema = kw.pop("schema")
-        super().__init__(schema=self.schema, **kw)
+        super(NamedField, self).__init__(schema=self.schema, **kw)
 
     def validate(self, value, interface):
-        super().validate(value)
+        super(NamedField, self).validate(value)
         for name, validator in getAdapters((self, value), interface):
             validator()
 
@@ -115,7 +115,7 @@ class NamedFile(NamedField):
     accept = ()
 
     def validate(self, value):
-        super().validate(value, IPluggableFileFieldValidation)
+        super(NamedFile, self).validate(value, IPluggableFileFieldValidation)
 
 
 @implementer(INamedImageField)
@@ -127,7 +127,7 @@ class NamedImage(NamedField):
     accept = ("image/*",)
 
     def validate(self, value):
-        super().validate(value, IPluggableImageFieldValidation)
+        super(NamedImage, self).validate(value, IPluggableImageFieldValidation)
 
 
 @implementer(INamedBlobFileField)
@@ -139,7 +139,7 @@ class NamedBlobFile(NamedField):
     accept = ()
 
     def validate(self, value):
-        super().validate(value, IPluggableFileFieldValidation)
+        super(NamedBlobFile, self).validate(value, IPluggableFileFieldValidation)
 
 
 @implementer(INamedBlobImageField)
@@ -151,4 +151,4 @@ class NamedBlobImage(NamedField):
     accept = ("image/*",)
 
     def validate(self, value):
-        super().validate(value, IPluggableImageFieldValidation)
+        super(NamedBlobImage, self).validate(value, IPluggableImageFieldValidation)

--- a/plone/namedfile/field.zcml
+++ b/plone/namedfile/field.zcml
@@ -4,6 +4,11 @@
     xmlns:browser="http://namespaces.zope.org/browser">
 
     <adapter
+        factory=".field.FileContenttypeValidator"
+        name="file_contenttype"
+    />
+
+    <adapter
         factory=".field.ImageContenttypeValidator"
         name="image_contenttype"
     />

--- a/plone/namedfile/handler.rst
+++ b/plone/namedfile/handler.rst
@@ -41,13 +41,23 @@ Named file
 
 ::
 
-    >>> field = NamedFile(__name__="dummy", title=u"Test",
-    ...     description=u"Test desc", required=False, readonly=True)
+    >>> field = NamedFile(
+    ...     __name__="dummy",
+    ...     accept=("audio/ogg", "audio/flac"),
+    ...     title=u"Test",
+    ...     description=u"Test desc",
+    ...     required=False,
+    ...     readonly=True
+    ... )
     >>> fieldType = IFieldNameExtractor(field)()
     >>> handler = getUtility(IFieldExportImportHandler, name=fieldType)
     >>> element = handler.write(field, u'dummy', fieldType) #doctest: +ELLIPSIS
     >>> print(prettyXML(element))
     <field name="dummy" type="plone.namedfile.field.NamedFile">
+      <accept>
+        <element>audio/ogg</element>
+        <element>audio/flac</element>
+      </accept>
       <description>Test desc</description>
       <readonly>True</readonly>
       <required>False</required>
@@ -56,6 +66,10 @@ Named file
 
     >>> element = etree.XML("""\
     ... <field name="dummy" type="plone.namedfile.field.NamedFile">
+    ...   <accept>
+    ...     <element>audio/ogg</element>
+    ...     <element>audio/flac</element>
+    ...   </accept>
     ...   <description>Test desc</description>
     ...   <missing_value />
     ...   <readonly>True</readonly>
@@ -69,6 +83,8 @@ Named file
     <class 'plone.namedfile.field.NamedFile'>
     >>> reciprocal.__name__
     'dummy'
+    >>> reciprocal.accept
+    ('audio/ogg', 'audio/flac')
     >>> print(reciprocal.title)
     Test
     >>> print(reciprocal.description)
@@ -84,13 +100,23 @@ Named image
 
 ::
 
-    >>> field = NamedImage(__name__="dummy", title=u"Test",
-    ...     description=u"Test desc", required=False, readonly=True)
+    >>> field = NamedImage(
+    ...     __name__="dummy",
+    ...     accept=("image/png", "image/webp"),
+    ...     title=u"Test",
+    ...     description=u"Test desc",
+    ...     required=False,
+    ...     readonly=True
+    ... )
     >>> fieldType = IFieldNameExtractor(field)()
     >>> handler = getUtility(IFieldExportImportHandler, name=fieldType)
     >>> element = handler.write(field, u'dummy', fieldType) #doctest: +ELLIPSIS
     >>> print(prettyXML(element))
     <field name="dummy" type="plone.namedfile.field.NamedImage">
+      <accept>
+        <element>image/png</element>
+        <element>image/webp</element>
+      </accept>
       <description>Test desc</description>
       <readonly>True</readonly>
       <required>False</required>
@@ -99,6 +125,10 @@ Named image
 
     >>> element = etree.XML("""\
     ... <field name="dummy" type="plone.namedfile.field.NamedImage">
+    ...   <accept>
+    ...     <element>image/png</element>
+    ...     <element>image/webp</element>
+    ...   </accept>
     ...   <description>Test desc</description>
     ...   <missing_value />
     ...   <readonly>True</readonly>
@@ -112,6 +142,8 @@ Named image
     <class 'plone.namedfile.field.NamedImage'>
     >>> reciprocal.__name__
     'dummy'
+    >>> reciprocal.accept
+    ('image/png', 'image/webp')
     >>> print(reciprocal.title)
     Test
     >>> print(reciprocal.description)
@@ -127,13 +159,23 @@ Named blob file
 
 ::
 
-    >>> field = NamedBlobFile(__name__="dummy", title=u"Test",
-    ...     description=u"Test desc", required=False, readonly=True)
+    >>> field = NamedBlobFile(
+    ...     __name__="dummy",
+    ...     accept=("audio/ogg", "audio/flac"),
+    ...     title=u"Test",
+    ...     description=u"Test desc",
+    ...     required=False,
+    ...     readonly=True
+    ... )
     >>> fieldType = IFieldNameExtractor(field)()
     >>> handler = getUtility(IFieldExportImportHandler, name=fieldType)
     >>> element = handler.write(field, u'dummy', fieldType) #doctest: +ELLIPSIS
     >>> print(prettyXML(element))
     <field name="dummy" type="plone.namedfile.field.NamedBlobFile">
+      <accept>
+        <element>audio/ogg</element>
+        <element>audio/flac</element>
+      </accept>
       <description>Test desc</description>
       <readonly>True</readonly>
       <required>False</required>
@@ -142,6 +184,10 @@ Named blob file
 
     >>> element = etree.XML("""\
     ... <field name="dummy" type="plone.namedfile.field.NamedBlobFile">
+    ...   <accept>
+    ...     <element>audio/ogg</element>
+    ...     <element>audio/flac</element>
+    ...   </accept>
     ...   <description>Test desc</description>
     ...   <missing_value />
     ...   <readonly>True</readonly>
@@ -155,6 +201,8 @@ Named blob file
     <class 'plone.namedfile.field.NamedBlobFile'>
     >>> reciprocal.__name__
     'dummy'
+    >>> reciprocal.accept
+    ('audio/ogg', 'audio/flac')
     >>> print(reciprocal.title)
     Test
     >>> print(reciprocal.description)
@@ -170,13 +218,23 @@ Named blob image
 
 ::
 
-    >>> field = NamedBlobImage(__name__="dummy", title=u"Test",
-    ...     description=u"Test desc", required=False, readonly=True)
+    >>> field = NamedBlobImage(
+    ...     __name__="dummy",
+    ...     accept=("image/png", "image/webp"),
+    ...     title=u"Test",
+    ...     description=u"Test desc",
+    ...     required=False,
+    ...     readonly=True
+    ... )
     >>> fieldType = IFieldNameExtractor(field)()
     >>> handler = getUtility(IFieldExportImportHandler, name=fieldType)
     >>> element = handler.write(field, u'dummy', fieldType) #doctest: +ELLIPSIS
     >>> print(prettyXML(element))
     <field name="dummy" type="plone.namedfile.field.NamedBlobImage">
+      <accept>
+        <element>image/png</element>
+        <element>image/webp</element>
+      </accept>
       <description>Test desc</description>
       <readonly>True</readonly>
       <required>False</required>
@@ -185,6 +243,10 @@ Named blob image
 
     >>> element = etree.XML("""\
     ... <field name="dummy" type="plone.namedfile.field.NamedBlobImage">
+    ...   <accept>
+    ...     <element>image/png</element>
+    ...     <element>image/webp</element>
+    ...   </accept>
     ...   <description>Test desc</description>
     ...   <missing_value />
     ...   <readonly>True</readonly>
@@ -198,6 +260,8 @@ Named blob image
     <class 'plone.namedfile.field.NamedBlobImage'>
     >>> reciprocal.__name__
     'dummy'
+    >>> reciprocal.accept
+    ('image/png', 'image/webp')
     >>> print(reciprocal.title)
     Test
     >>> print(reciprocal.description)
@@ -206,3 +270,87 @@ Named blob image
     False
     >>> reciprocal.readonly
     True
+
+
+Test the default accepted media type
+------------------------------------
+
+Named file::
+
+    >>> field = NamedFile()
+    >>> field.accept
+    ()
+    >>> fieldType = IFieldNameExtractor(field)()
+    >>> handler = getUtility(IFieldExportImportHandler, name=fieldType)
+    >>> element = handler.write(field, u'dummy', fieldType)
+    >>> print(prettyXML(element))
+    <field name="dummy" type="plone.namedfile.field.NamedFile"/>
+
+    >>> element__ = etree.XML("""\
+    ... <field name="dummy" type="plone.namedfile.field.NamedFile"/>
+    ... """)
+
+    >>> reciprocal__ = handler.read(element__)
+    >>> reciprocal__.accept
+    ()
+
+
+Named image::
+
+    >>> field = NamedImage()
+    >>> field.accept
+    ('image/*',)
+    >>> fieldType = IFieldNameExtractor(field)()
+    >>> handler = getUtility(IFieldExportImportHandler, name=fieldType)
+    >>> element = handler.write(field, u'dummy', fieldType)
+    >>> print(prettyXML(element))
+    <field name="dummy" type="plone.namedfile.field.NamedImage"/>
+
+    >>> element = etree.XML("""\
+    ... <field type="plone.namedfile.field.NamedImage"/>
+    ... """)
+
+    >>> reciprocal = handler.read(element)
+    >>> reciprocal.accept
+    ('image/*',)
+
+
+Named blob file::
+
+    >>> field = NamedBlobFile()
+    >>> field.accept
+    ()
+    >>> fieldType = IFieldNameExtractor(field)()
+    >>> handler = getUtility(IFieldExportImportHandler, name=fieldType)
+    >>> element = handler.write(field, u'dummy', fieldType)
+    >>> print(prettyXML(element))
+    <field name="dummy" type="plone.namedfile.field.NamedBlobFile"/>
+
+    >>> element = etree.XML("""\
+    ... <field type="plone.namedfile.field.NamedBlobFile"/>
+    ... """)
+
+    >>> reciprocal = handler.read(element)
+    >>> reciprocal.accept
+    ()
+
+
+Named blob image::
+
+    >>> field = NamedBlobImage()
+    >>> field.accept
+    ('image/*',)
+    >>> fieldType = IFieldNameExtractor(field)()
+    >>> handler = getUtility(IFieldExportImportHandler, name=fieldType)
+    >>> element = handler.write(field, u'dummy', fieldType)
+    >>> print(prettyXML(element))
+    <field name="dummy" type="plone.namedfile.field.NamedBlobImage"/>
+
+    >>> element = etree.XML("""\
+    ... <field type="plone.namedfile.field.NamedBlobImage"/>
+    ... """)
+
+    >>> reciprocal = handler.read(element)
+    >>> reciprocal.accept
+    ('image/*',)
+

--- a/plone/namedfile/interfaces.py
+++ b/plone/namedfile/interfaces.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from zope import schema
+from zope.i18nmessageid import MessageFactory
 from zope.interface import Interface
 from zope.schema.interfaces import IObject
+
+
+# We don't have translations here, but this allows
+_ = MessageFactory("plone")
 
 
 HAVE_BLOBS = True
@@ -109,10 +114,45 @@ class INamedFileField(INamedField):
     """Field for storing INamedFile objects.
     """
 
+    accept = schema.Tuple(
+        title=_("namedfile_accept_title", default="accept types"),
+        description=_(
+            "namedfile_accept_description",
+            default=(
+                'The media types which are allowed for this field. '
+                'Unset to allow any type. '
+                'Can be any valid identifier for the "accept" attribute of '
+                'the HTML file input, like extensions (e.g. ".mp3") or IANA '
+                'media types (e.g. "image/webp").'
+            ),
+        ),
+        value_type=schema.TextLine(),
+        default=(),
+        required=False,
+    )
+
 
 class INamedImageField(INamedField):
     """Field for storing INamedImage objects.
     """
+
+    accept = schema.Tuple(
+        title=_("namedimage_accept_title", default="accept types"),
+        description=_(
+            "namedimage_accept_description",
+            default=(
+                'The media types which are allowed for this image field. '
+                'The default is to allow any "image/*" content type. '
+                'Unset to allow any type. '
+                'Can be any valid identifier for the "accept" attribute of '
+                'the HTML file input, like extensions (e.g. ".jpg") or IANA '
+                'media types (e.g. "image/webp").'
+            ),
+        ),
+        value_type=schema.TextLine(),
+        default=("image/*",),
+        required=False,
+    )
 
 
 class IStorage(Interface):

--- a/plone/namedfile/tests/test_doctests.py
+++ b/plone/namedfile/tests/test_doctests.py
@@ -26,6 +26,7 @@ class Py23DocChecker(doctest.OutputChecker):
                 "WrongType", "zope.schema._bootstrapinterfaces.WrongType", got)
             got = got.replace(
                 "filename*=\"utf-8''test.txt\"", "filename*=utf-8''test.txt")
+            got = re.sub("InvalidFile", "plone.namedfile.field.InvalidFile", got)
 
         if six.PY3:
             got = re.sub("b'(.*?)'", "'\\1'", got)

--- a/plone/namedfile/tests/test_image.py
+++ b/plone/namedfile/tests/test_image.py
@@ -3,9 +3,6 @@
 
 from plone.namedfile.file import NamedImage
 from plone.namedfile.interfaces import INamedImage
-from plone.namedfile.tests import getFile
-from plone.namedfile.utils import get_contenttype
-from plone.namedfile.testing import PLONE_NAMEDFILE_INTEGRATION_TESTING
 from zope.interface.verify import verifyClass
 
 import unittest
@@ -61,29 +58,3 @@ class TestImage(unittest.TestCase):
     def testInterface(self):
         self.assertTrue(INamedImage.implementedBy(NamedImage))
         self.assertTrue(verifyClass(INamedImage, NamedImage))
-
-    def test_get_contenttype(self):
-        self.assertEqual(
-            get_contenttype(
-                NamedImage(
-                    getFile('image.gif'),
-                    contentType='image/gif')),
-            'image/gif')
-        self.assertEqual(
-            get_contenttype(
-                NamedImage(
-                    getFile('image.gif'),
-                    filename=u'image.gif')),
-            'image/gif')
-        self.assertEqual(
-            get_contenttype(
-                NamedImage(
-                    getFile('image.tif'),
-                    filename=u'image.tif')),
-            'image/tiff')
-        self.assertEqual(
-            get_contenttype(
-                NamedImage(
-                    getFile('notimage.doc'),
-                    filename=u'notimage.doc')),
-            'application/msword')

--- a/plone/namedfile/tests/test_image.py
+++ b/plone/namedfile/tests/test_image.py
@@ -81,48 +81,9 @@ class TestImage(unittest.TestCase):
                     getFile('image.tif'),
                     filename=u'image.tif')),
             'image/tiff')
-        self.assertEqual(get_contenttype(
-            NamedImage(getFile('notimage.doc'),
-                       filename=u'notimage.doc')),
+        self.assertEqual(
+            get_contenttype(
+                NamedImage(
+                    getFile('notimage.doc'),
+                    filename=u'notimage.doc')),
             'application/msword')
-
-
-class TestValidation(unittest.TestCase):
-
-    layer = PLONE_NAMEDFILE_INTEGRATION_TESTING
-
-    def _makeImage(self, *args, **kw):
-        return NamedImage(*args, **kw)
-
-    def testImageValidation(self):
-        from plone.namedfile.field import InvalidImageFile
-        from plone.namedfile.field import validate_image_field
-        from plone.namedfile.interfaces import INamedImageField
-        from zope.interface import implementer
-
-        @implementer(INamedImageField)
-        class FakeField(object):
-            __name__ = 'logo'
-
-        # field is empty
-        validate_image_field(FakeField(), None)
-
-        # field has an empty file
-        image = self._makeImage()
-        self.assertRaises(
-            InvalidImageFile,
-            validate_image_field,
-            FakeField(),
-            image)
-
-        # field has an image file
-        image._setData(zptlogo)
-        validate_image_field(FakeField(), image)
-
-        notimage = NamedImage(getFile('notimage.doc'),
-                              filename=u'notimage.doc')
-        self.assertRaises(
-            InvalidImageFile,
-            validate_image_field,
-            FakeField(),
-            notimage)

--- a/plone/namedfile/tests/test_utils.py
+++ b/plone/namedfile/tests/test_utils.py
@@ -1,0 +1,64 @@
+from plone.namedfile.file import NamedImage
+from plone.namedfile.tests import getFile
+from plone.namedfile.utils import get_contenttype
+
+import unittest
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_get_contenttype(self):
+        self.assertEqual(
+            get_contenttype(
+                NamedImage(
+                    getFile("image.gif"),
+                    contentType="image/gif",
+                )
+            ),
+            "image/gif",
+        )
+        self.assertEqual(
+            get_contenttype(
+                NamedImage(
+                    getFile("image.gif"),
+                    filename="image.gif",
+                )
+            ),
+            "image/gif",
+        )
+        self.assertEqual(
+            get_contenttype(
+                NamedImage(
+                    getFile("image.tif"),
+                    filename="image.tif",
+                )
+            ),
+            "image/tiff",
+        )
+        self.assertEqual(
+            get_contenttype(
+                NamedImage(
+                    getFile("notimage.doc"),
+                    filename="notimage.doc",
+                )
+            ),
+            "application/msword",
+        )
+
+        # Filename only detection of a non-IANA registered type.
+        self.assertEqual(
+            get_contenttype(filename="image.webp"),
+            "image/webp",
+        )
+
+        # Filename only detection of a non-IANA registered type.
+        self.assertEqual(
+            get_contenttype(filename="song.midi"),
+            "audio/midi",
+        )
+
+        # Detection of a surely not registered type.
+        self.assertEqual(
+            get_contenttype(filename="nothing.plonenamedfile"),
+            "application/octet-stream",
+        )

--- a/plone/namedfile/tests/test_utils.py
+++ b/plone/namedfile/tests/test_utils.py
@@ -21,7 +21,7 @@ class TestUtils(unittest.TestCase):
             get_contenttype(
                 NamedImage(
                     getFile("image.gif"),
-                    filename="image.gif",
+                    filename=u"image.gif",
                 )
             ),
             "image/gif",
@@ -30,7 +30,7 @@ class TestUtils(unittest.TestCase):
             get_contenttype(
                 NamedImage(
                     getFile("image.tif"),
-                    filename="image.tif",
+                    filename=u"image.tif",
                 )
             ),
             "image/tiff",
@@ -39,7 +39,7 @@ class TestUtils(unittest.TestCase):
             get_contenttype(
                 NamedImage(
                     getFile("notimage.doc"),
-                    filename="notimage.doc",
+                    filename=u"notimage.doc",
                 )
             ),
             "application/msword",
@@ -47,18 +47,18 @@ class TestUtils(unittest.TestCase):
 
         # Filename only detection of a non-IANA registered type.
         self.assertEqual(
-            get_contenttype(filename="image.webp"),
+            get_contenttype(filename=u"image.webp"),
             "image/webp",
         )
 
         # Filename only detection of a non-IANA registered type.
         self.assertEqual(
-            get_contenttype(filename="song.midi"),
+            get_contenttype(filename=u"song.midi"),
             "audio/midi",
         )
 
         # Detection of a surely not registered type.
         self.assertEqual(
-            get_contenttype(filename="nothing.plonenamedfile"),
+            get_contenttype(filename=u"nothing.plonenamedfile"),
             "application/octet-stream",
         )

--- a/plone/namedfile/tests/test_validation.py
+++ b/plone/namedfile/tests/test_validation.py
@@ -1,0 +1,115 @@
+from plone.namedfile import field
+from plone.namedfile import file
+from plone.namedfile.testing import PLONE_NAMEDFILE_INTEGRATION_TESTING
+from plone.namedfile.tests import getFile
+
+import unittest
+
+
+class TestValidation(unittest.TestCase):
+
+    layer = PLONE_NAMEDFILE_INTEGRATION_TESTING
+
+    def test_validation_NamedImage_default(self):
+        # Testing the default accepted media types
+        image_field = field.NamedImage(
+            required=False,
+        )
+
+        # field is empty, passes
+        image_field.validate(None)
+
+        # field has an empty file, fails
+        # NOTE: This fails not because the NamedFile is empty but because the
+        #       fallback default mimetype is "application/octet-stream".
+        #       Not sure, if we should change this behavior.
+        #       See: plone.namedfile.utils.get_contenttype
+        named_image = file.NamedImage()
+        self.assertRaises(field.InvalidImageFile, image_field.validate, named_image)
+
+        # field has an png image file, passes
+        named_image = file.NamedImage(getFile("image.png"), filename="image.png")
+        image_field.validate(named_image)
+
+        # field has an gif image file, passes
+        named_image = file.NamedImage(getFile("image.gif"), filename="image.gif")
+        image_field.validate(named_image)
+
+        # field has a non-image file, fails
+        named_image = file.NamedImage(getFile("notimage.doc"), filename="notimage.doc")
+        self.assertRaises(field.InvalidImageFile, image_field.validate, named_image)
+
+    def test_validation_NamedImage_custom(self):
+        # Testing the default accepted media types
+        image_field = field.NamedImage(
+            accept=("image/png", ".jpg"),
+            required=False,
+        )
+
+        # field is empty, passes
+        image_field.validate(None)
+
+        # field has an empty file, fails
+        # NOTE: This fails not because the NamedFile is empty but because the
+        #       fallback default mimetype is "application/octet-stream".
+        #       Not sure, if we should change this behavior.
+        #       See: plone.namedfile.utils.get_contenttype
+        named_image = file.NamedImage()
+        self.assertRaises(field.InvalidImageFile, image_field.validate, named_image)
+
+        # field has a png image file, passes
+        named_image = file.NamedImage(getFile("image.png"), filename="image.png")
+        image_field.validate(named_image)
+
+        # field has a jpg image file, passes also
+        named_image = file.NamedImage(getFile("image.jpg"), filename="image.jpg")
+        image_field.validate(named_image)
+
+        # field has a gif image file, fails because it's not in the accepted
+        # media types
+        named_image = file.NamedImage(getFile("image.gif"), filename="image.gif")
+        self.assertRaises(field.InvalidImageFile, image_field.validate, named_image)
+
+        # field has a non-image file, fails
+        named_image = file.NamedImage(getFile("notimage.doc"), filename="notimage.doc")
+        self.assertRaises(field.InvalidImageFile, image_field.validate, named_image)
+
+    def test_validation_NamedFile_default(self):
+        # Testing the default accepted media types
+        file_field = field.NamedFile(
+            required=False,
+        )
+
+        # field is empty, passes
+        file_field.validate(None)
+
+        # field has n pdf file file, passes
+        named_file = file.NamedFile(getFile("file.pdf"), filename="file.pdf")
+        file_field.validate(named_file)
+
+        # field has a gif file, passes
+        named_file = file.NamedFile(getFile("image.gif"), filename="image.gif")
+        file_field.validate(named_file)
+
+    def test_validation_NamedFile_custom(self):
+        # Testing the default accepted media types
+        file_field = field.NamedFile(
+            accept=("application/pdf", ".jpg"),
+            required=False,
+        )
+
+        # field is empty, passes
+        file_field.validate(None)
+
+        # field has a pdf file file, passes
+        named_file = file.NamedFile(getFile("file.pdf"), filename="file.pdf")
+        file_field.validate(named_file)
+
+        # field has a jpg file file, passes also
+        named_file = file.NamedFile(getFile("image.jpg"), filename="image.jpg")
+        file_field.validate(named_file)
+
+        # field has a gif file, fails because it's not in the accepted media
+        # types
+        named_file = file.NamedFile(getFile("image.gif"), filename="image.gif")
+        self.assertRaises(field.InvalidFile, file_field.validate, named_file)

--- a/plone/namedfile/tests/test_validation.py
+++ b/plone/namedfile/tests/test_validation.py
@@ -28,15 +28,15 @@ class TestValidation(unittest.TestCase):
         self.assertRaises(field.InvalidImageFile, image_field.validate, named_image)
 
         # field has an png image file, passes
-        named_image = file.NamedImage(getFile("image.png"), filename="image.png")
+        named_image = file.NamedImage(getFile("image.png"), filename=u"image.png")
         image_field.validate(named_image)
 
         # field has an gif image file, passes
-        named_image = file.NamedImage(getFile("image.gif"), filename="image.gif")
+        named_image = file.NamedImage(getFile("image.gif"), filename=u"image.gif")
         image_field.validate(named_image)
 
         # field has a non-image file, fails
-        named_image = file.NamedImage(getFile("notimage.doc"), filename="notimage.doc")
+        named_image = file.NamedImage(getFile("notimage.doc"), filename=u"notimage.doc")
         self.assertRaises(field.InvalidImageFile, image_field.validate, named_image)
 
     def test_validation_NamedImage_custom(self):
@@ -58,20 +58,20 @@ class TestValidation(unittest.TestCase):
         self.assertRaises(field.InvalidImageFile, image_field.validate, named_image)
 
         # field has a png image file, passes
-        named_image = file.NamedImage(getFile("image.png"), filename="image.png")
+        named_image = file.NamedImage(getFile("image.png"), filename=u"image.png")
         image_field.validate(named_image)
 
         # field has a jpg image file, passes also
-        named_image = file.NamedImage(getFile("image.jpg"), filename="image.jpg")
+        named_image = file.NamedImage(getFile("image.jpg"), filename=u"image.jpg")
         image_field.validate(named_image)
 
         # field has a gif image file, fails because it's not in the accepted
         # media types
-        named_image = file.NamedImage(getFile("image.gif"), filename="image.gif")
+        named_image = file.NamedImage(getFile("image.gif"), filename=u"image.gif")
         self.assertRaises(field.InvalidImageFile, image_field.validate, named_image)
 
         # field has a non-image file, fails
-        named_image = file.NamedImage(getFile("notimage.doc"), filename="notimage.doc")
+        named_image = file.NamedImage(getFile("notimage.doc"), filename=u"notimage.doc")
         self.assertRaises(field.InvalidImageFile, image_field.validate, named_image)
 
     def test_validation_NamedFile_default(self):
@@ -84,11 +84,11 @@ class TestValidation(unittest.TestCase):
         file_field.validate(None)
 
         # field has n pdf file file, passes
-        named_file = file.NamedFile(getFile("file.pdf"), filename="file.pdf")
+        named_file = file.NamedFile(getFile("file.pdf"), filename=u"file.pdf")
         file_field.validate(named_file)
 
         # field has a gif file, passes
-        named_file = file.NamedFile(getFile("image.gif"), filename="image.gif")
+        named_file = file.NamedFile(getFile("image.gif"), filename=u"image.gif")
         file_field.validate(named_file)
 
     def test_validation_NamedFile_custom(self):
@@ -102,14 +102,14 @@ class TestValidation(unittest.TestCase):
         file_field.validate(None)
 
         # field has a pdf file file, passes
-        named_file = file.NamedFile(getFile("file.pdf"), filename="file.pdf")
+        named_file = file.NamedFile(getFile("file.pdf"), filename=u"file.pdf")
         file_field.validate(named_file)
 
         # field has a jpg file file, passes also
-        named_file = file.NamedFile(getFile("image.jpg"), filename="image.jpg")
+        named_file = file.NamedFile(getFile("image.jpg"), filename=u"image.jpg")
         file_field.validate(named_file)
 
         # field has a gif file, fails because it's not in the accepted media
         # types
-        named_file = file.NamedFile(getFile("image.gif"), filename="image.gif")
+        named_file = file.NamedFile(getFile("image.gif"), filename=u"image.gif")
         self.assertRaises(field.InvalidFile, file_field.validate, named_file)

--- a/plone/namedfile/usage.rst
+++ b/plone/namedfile/usage.rst
@@ -153,6 +153,55 @@ The filename must be set to a unicode string, not a bytestring::
     zope.schema._bootstrapinterfaces.WrongType: ...
 
 
+Restricting media types
+-----------------------
+
+It is possible to define accepted media types, just like with the "accept"
+attribute of HTML file inputs. You can pass a tuple of file extensions or media
+type values::
+
+
+    >>> class IFileContainerConstrained(Interface):
+    ...     file = field.NamedFile(title=u"File", accept=("text/plain", ".pdf"))
+
+    >>> @implementer(IFileContainerConstrained)
+    ... class FileContainerConstrained:
+    ...     __allow_access_to_unprotected_subobjects__ = 1
+    ...     def __init__(self):
+    ...         self.file = namedfile.NamedFile()
+
+    >>> container_constrained = FileContainerConstrained()
+
+
+Adding valid file types and checking passes. Note, that the validation logic is
+called by the framework and does not need to be called manualle, like in this
+test.
+::
+
+    >>> container_constrained.file = namedfile.NamedFile(
+    ...     'dummy test data',
+    ...     filename=u"test.txt"
+    ... )
+    >>> IFileContainerConstrained["file"].validate(container_constrained.file)
+
+    >>> container_constrained.file = namedfile.NamedFile(
+    ...     'dummy test data',
+    ...     filename=u"test.pdf"
+    ... )
+    >>> IFileContainerConstrained["file"].validate(container_constrained.file)
+
+Adding invalid file types and checking fails with a ValidationError::
+
+    >>> container_constrained.file = namedfile.NamedFile(
+    ...     'dummy test data',
+    ...     filename=u"test.wav"
+    ... )
+    >>> IFileContainerConstrained["file"].validate(container_constrained.file)
+    Traceback (most recent call last):
+    ...
+    plone.namedfile.field.InvalidFile: ('audio/x-wav', 'file')
+
+
 Download view
 -------------
 

--- a/plone/namedfile/utils/__init__.py
+++ b/plone/namedfile/utils/__init__.py
@@ -14,7 +14,6 @@ from zope.deprecation import deprecate
 from zope.interface import implementer
 
 import mimetypes
-import os.path
 import piexif
 import PIL.Image
 import six
@@ -103,8 +102,7 @@ def get_contenttype(
 
     filename = getattr(file, 'filename', filename)
     if filename:
-        extension = os.path.splitext(filename)[1].lower()
-        return mimetypes.types_map.get(extension, 'application/octet-stream')
+        return mimetypes.guess_type(filename, strict=False)[0] or default
 
     return default
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 import os
 
 
-version = '5.6.2.dev0'
+version = '5.7.0.dev0'
 
 description = 'File types and fields for images, files and blob files with ' \
               'filenames'


### PR DESCRIPTION
Support to constrain files to specific content types with a "allowedContentTypes" attribute on file and image fields.

Fixes: #157

**BRANCH‌ FOR 5.x / Plone 5.x**

Related: https://github.com/plone/plone.namedfile/pull/158