### PR TITLE
Fix: Upload a svg without width and height set

### DIFF
--- a/news/161.bugfix
+++ b/news/161.bugfix
@@ -1,0 +1,1 @@
+Fix: Upload a svg without width and height set  @dobri1408

--- a/plone/namedfile/utils/svg_utils.py
+++ b/plone/namedfile/utils/svg_utils.py
@@ -35,7 +35,6 @@ def process_svg(data):
 
         if (w == 0 or h == 0) and view_box:
             w, h = calculate_dimensions_from_viewbox(view_box)
-        print(w,h)
         w = w if w > 1 else 1
         h = h if h > 1 else 1
     except et.ParseError as e:

--- a/plone/namedfile/utils/svg_utils.py
+++ b/plone/namedfile/utils/svg_utils.py
@@ -9,7 +9,6 @@ log = getLogger(__name__)
 
 def calculate_dimensions_from_viewbox(view_box):
         parts = [float(x) for x in view_box.split()]
-        print(f"Parsed viewBox parts: {parts}")
         if len(parts) == 4:
             width = int(parts[2] - parts[0])
             height = int(parts[3] - parts[1])

--- a/plone/namedfile/utils/svg_utils.py
+++ b/plone/namedfile/utils/svg_utils.py
@@ -7,22 +7,6 @@ import xml.etree.ElementTree as et
 
 log = getLogger(__name__)
 
-def dimension_int(dimension):
-    if isinstance(dimension, str):
-        try:
-            _dimension = int(float(re.sub(r"[^\d\.]", "", dimension)))
-        except ValueError:
-            _dimension = 0
-    elif isinstance(dimension, int):
-        _dimension = dimension
-    elif isinstance(dimension, float):
-        _dimension = int(dimension)
-    else:
-        _dimension = 0
-
-    return _dimension
-
-
 def calculate_dimensions_from_viewbox(view_box):
         parts = [float(x) for x in view_box.split()]
         print(f"Parsed viewBox parts: {parts}")
@@ -64,3 +48,19 @@ def process_svg(data):
         content_type = "image/svg+xml"
 
     return content_type, w, h
+
+
+def dimension_int(dimension):
+    if isinstance(dimension, str):
+        try:
+            _dimension = int(float(re.sub(r"[^\d\.]", "", dimension)))
+        except ValueError:
+            _dimension = 0
+    elif isinstance(dimension, int):
+        _dimension = dimension
+    elif isinstance(dimension, float):
+        _dimension = int(dimension)
+    else:
+        _dimension = 0
+
+    return _dimension

--- a/plone/namedfile/utils/svg_utils.py
+++ b/plone/namedfile/utils/svg_utils.py
@@ -10,9 +10,7 @@ log = getLogger(__name__)
 def calculate_dimensions_from_viewbox(view_box):
         parts = [float(x) for x in view_box.split()]
         if len(parts) == 4:
-            width = int(parts[2] - parts[0])
-            height = int(parts[3] - parts[1])
-            return width, height
+            return int(parts[2]), int(parts[3])
         return 1, 1
 
 


### PR DESCRIPTION
If you upload an SVG that doesn't have  width and height attribute, like the one found https://drive.google.com/file/d/15gPPxE-K5k8XYWmgreKX6aWD2FQ6zvM5/view?usp=sharing, the scaling will be incorrect. This occurs because the SVG utilities will default assume the dimensions are 1x1, despite the fact that the actual width and height can be derived from the viewBox attribute.