### PR TITLE
feat: set canonical header for file

### DIFF
--- a/news/163.feature
+++ b/news/163.feature
@@ -1,0 +1,1 @@
+set canonical header for file. @mamico

--- a/news/163.feature
+++ b/news/163.feature
@@ -1,1 +1,1 @@
-set canonical header for file. @mamico
+Set `Link` header with `rel="canonical"` for file downloads. @mamico

--- a/plone/namedfile/browser.py
+++ b/plone/namedfile/browser.py
@@ -132,7 +132,7 @@ class Download(BrowserView):
         if filename is None:
             return f"{self.context.absolute_url()}/@@download/{self.fieldname}"
         else:
-            return f"{self.context.absolute_url()}/@@download/{self.fieldname}/filename"
+            return f"{self.context.absolute_url()}/@@download/{self.fieldname}/{filename}"
 
     def set_headers(self, file):
         # With filename None, set_headers will not add the download headers.

--- a/plone/namedfile/browser.py
+++ b/plone/namedfile/browser.py
@@ -127,6 +127,13 @@ class Download(BrowserView):
         except ValueError:
             return default
 
+    def get_canonical(self, file):
+        filename = getattr(file, "filename", None)
+        if filename is None:
+            return f"{self.context.absolute_url()}/@@download/{self.fieldname}"
+        else:
+            return f"{self.context.absolute_url()}/@@download/{self.fieldname}/filename"
+
     def set_headers(self, file):
         # With filename None, set_headers will not add the download headers.
         if not self.filename:
@@ -135,7 +142,8 @@ class Download(BrowserView):
                 self.filename = self.fieldname
                 if self.filename is None:
                     self.filename = "file.ext"
-        set_headers(file, self.request.response, filename=self.filename)
+        canonical =  self.get_canonical(file)
+        set_headers(file, self.request.response, filename=self.filename, canonical=canonical)
 
     def _getFile(self):
         if not self.fieldname:
@@ -185,4 +193,5 @@ class DisplayFile(Download):
                 if mimetype not in self.allowed_inline_mimetypes:
                     # Let the Download view handle this.
                     return super().set_headers(file)
-        set_headers(file, self.request.response)
+        canonical =  self.get_canonical(file)
+        set_headers(file, self.request.response, canonical=canonical)

--- a/plone/namedfile/tests/test_display_file.py
+++ b/plone/namedfile/tests/test_display_file.py
@@ -49,15 +49,6 @@ def get_disposition_header(browser):
     return browser.headers.get(name, None)
 
 
-def get_canonical_header(browser):
-    name = "Link"
-    for header, value in browser.headers.items():
-        if header == name or header == name.lower():
-            if 'rel="canonical"' in map(str.strip, value.split(";")):
-                return value
-    return None
-
-
 def custom_available_sizes():
     # Define available image scales.
     return {"custom": (10, 10)}
@@ -105,16 +96,12 @@ class TestAttackVectorNamedImage(unittest.TestCase):
         self.assertIsNotNone(header)
         self.assertIn("attachment", header)
         self.assertIn("filename", header)
-        header = get_canonical_header(browser)
-        self.assertTrue(header.startswith(f"<{base_url}/@@download/{self.field_name}>"))
 
     def assert_display_inline_works(self, base_url):
         # Test that displaying this file inline works.
         browser = self.get_anon_browser()
         browser.open(base_url + f"/@@display-file/{self.field_name}")
         self.assertIsNone(get_disposition_header(browser))
-        header = get_canonical_header(browser)
-        self.assertTrue(header.startswith(f"<{base_url}/@@download/{self.field_name}>"))
 
     def assert_display_inline_is_download(self, base_url):
         # Test that displaying this file inline turns into a download.
@@ -124,8 +111,6 @@ class TestAttackVectorNamedImage(unittest.TestCase):
         self.assertIsNotNone(header)
         self.assertIn("attachment", header)
         self.assertIn("filename", header)
-        header = get_canonical_header(browser)
-        self.assertTrue(header.startswith(f"<{base_url}/@@download/{self.field_name}>"))
 
     def assert_scale_view_works(self, base_url):
         # Test that accessing a scale view shows the image inline.

--- a/plone/namedfile/tests/test_display_file.py
+++ b/plone/namedfile/tests/test_display_file.py
@@ -49,6 +49,15 @@ def get_disposition_header(browser):
     return browser.headers.get(name, None)
 
 
+def get_canonical_header(browser):
+    name = "Link"
+    for header, value in browser.headers.items():
+        if header == name or header == name.lower():
+            if 'rel="canonical"' in map(str.strip, value.split(";")):
+                return value
+    return None
+
+
 def custom_available_sizes():
     # Define available image scales.
     return {"custom": (10, 10)}
@@ -96,12 +105,16 @@ class TestAttackVectorNamedImage(unittest.TestCase):
         self.assertIsNotNone(header)
         self.assertIn("attachment", header)
         self.assertIn("filename", header)
+        header = get_canonical_header(browser)
+        self.assertTrue(header.startswith(f"<{base_url}/@@download/{self.field_name}>"))
 
     def assert_display_inline_works(self, base_url):
         # Test that displaying this file inline works.
         browser = self.get_anon_browser()
         browser.open(base_url + f"/@@display-file/{self.field_name}")
         self.assertIsNone(get_disposition_header(browser))
+        header = get_canonical_header(browser)
+        self.assertTrue(header.startswith(f"<{base_url}/@@download/{self.field_name}>"))
 
     def assert_display_inline_is_download(self, base_url):
         # Test that displaying this file inline turns into a download.
@@ -111,6 +124,8 @@ class TestAttackVectorNamedImage(unittest.TestCase):
         self.assertIsNotNone(header)
         self.assertIn("attachment", header)
         self.assertIn("filename", header)
+        header = get_canonical_header(browser)
+        self.assertTrue(header.startswith(f"<{base_url}/@@download/{self.field_name}>"))
 
     def assert_scale_view_works(self, base_url):
         # Test that accessing a scale view shows the image inline.

--- a/plone/namedfile/usage.rst
+++ b/plone/namedfile/usage.rst
@@ -32,6 +32,9 @@ These store data with the following types::
     ...         self.image = namedfile.NamedImage()
     ...         self.blob = namedfile.NamedBlobFile()
     ...         self.blobimage = namedfile.NamedBlobImage()
+    ...
+    ...     def absolute_url(self):
+    ...         return "http://foo/bar"
 
 
 File data and content type

--- a/plone/namedfile/usage.rst
+++ b/plone/namedfile/usage.rst
@@ -229,6 +229,8 @@ We will test this with a dummy request, faking traversal::
     'text/plain'
     >>> request.response.getHeader('Content-Disposition')
     "attachment; filename*=UTF-8''test.txt"
+    >>> request.response.getHeader('Link')
+    '<http://foo/bar/@@download/simple/test.txt>; rel="canonical"'
 
     >>> request = TestRequest()
     >>> download = Download(container, request).publishTraverse(request, 'blob')
@@ -241,6 +243,8 @@ We will test this with a dummy request, faking traversal::
     'text/plain'
     >>> request.response.getHeader('Content-Disposition')
     "attachment; filename*=UTF-8''test.txt"
+    >>> request.response.getHeader('Link')
+    '<http://foo/bar/@@download/blob/test.txt>; rel="canonical"'
 
     >>> request = TestRequest()
     >>> download = Download(container, request).publishTraverse(request, 'image')
@@ -253,6 +257,8 @@ We will test this with a dummy request, faking traversal::
     'image/foo'
     >>> request.response.getHeader('Content-Disposition')
     "attachment; filename*=UTF-8''zpt.gif"
+    >>> request.response.getHeader('Link')
+    '<http://foo/bar/@@download/image/zpt.gif>; rel="canonical"'
 
     >>> request = TestRequest()
     >>> download = Download(container, request).publishTraverse(request, 'blobimage')
@@ -265,6 +271,8 @@ We will test this with a dummy request, faking traversal::
     'image/foo'
     >>> request.response.getHeader('Content-Disposition')
     "attachment; filename*=UTF-8''zpt.gif"
+    >>> request.response.getHeader('Link')
+    '<http://foo/bar/@@download/blobimage/zpt.gif>; rel="canonical"'
 
 Range support
 -------------

--- a/plone/namedfile/utils/__init__.py
+++ b/plone/namedfile/utils/__init__.py
@@ -150,7 +150,7 @@ def set_headers(file, response, filename=None, canonical=None):
         )
 
     if canonical is not None:
-        response.setHeader("Link", f'<{quote(canonical, safe='')}>; rel="canonical"')
+        response.setHeader("Link", f'<{quote(canonical, safe="/:&?=@")}>; rel="canonical"')
 
 def stream_data(file, start=0, end=None):
     """Return the given file as a stream if possible."""

--- a/plone/namedfile/utils/__init__.py
+++ b/plone/namedfile/utils/__init__.py
@@ -130,7 +130,7 @@ def get_contenttype(file=None, filename=None, default="application/octet-stream"
     return default
 
 
-def set_headers(file, response, filename=None):
+def set_headers(file, response, filename=None, canonical=None):
     """Set response headers for the given file. If filename is given, set
     the Content-Disposition to attachment.
     """
@@ -149,6 +149,8 @@ def set_headers(file, response, filename=None):
             "Content-Disposition", f"attachment; filename*=UTF-8''{filename}"
         )
 
+    if canonical is not None:
+        response.setHeader("Link", f'<{canonical}>; rel="canonical"')
 
 def stream_data(file, start=0, end=None):
     """Return the given file as a stream if possible."""

--- a/plone/namedfile/utils/__init__.py
+++ b/plone/namedfile/utils/__init__.py
@@ -150,7 +150,7 @@ def set_headers(file, response, filename=None, canonical=None):
         )
 
     if canonical is not None:
-        response.setHeader("Link", f'<{canonical}>; rel="canonical"')
+        response.setHeader("Link", f'<{quote(canonical, safe='')}>; rel="canonical"')
 
 def stream_data(file, start=0, end=None):
     """Return the given file as a stream if possible."""


### PR DESCRIPTION
File has multiple urls for same content, eg

http://domain/path/foo.pdf/@@download/file
http://domain/path/foo.pdf/@@download/file/foo.pdf
http://domain/path/foo.pdf/@@display-file/file
...

This PR is intended to define a canonical url to avoid duplication and SEO penalties.

see https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-header-method