### PR TITLE
faster uploads by avoiding unneed large blob reads

### DIFF
--- a/news/167.bugfix
+++ b/news/167.bugfix
@@ -1,0 +1,1 @@
+Adjusted schema validation to prevent file/image loading during upload/import

--- a/plone/namedfile/field.py
+++ b/plone/namedfile/field.py
@@ -143,7 +143,7 @@ class NamedBlobFile(NamedField):
         # because schema validation checks the property exists
         # which loads the entire file into memory for no reaon.
         # This can slow down imports and uploads a lot.
-        # TODO: better fix might be get DX to check for a decorator first 
+        # TODO: better fix might be get zope.schema to check for a decorator first 
         # - https://stackoverflow.com/questions/16169948/check-if-something-is-an-attribute-or-decorator-in-python
         self.schema = INamedTyped
         try:

--- a/plone/namedfile/field.py
+++ b/plone/namedfile/field.py
@@ -141,10 +141,9 @@ class NamedBlobFile(NamedField):
     def validate(self, value):
         # Bit of a hack but we avoid loading the .data into memory
         # because schema validation checks the property exists
-        # which loads the entire file into memory for no reaon.
+        # which loads the entire file into memory without checking the data.
         # This can slow down imports and uploads a lot.
-        # TODO: better fix might be get zope.schema to check for a decorator first 
-        # - https://stackoverflow.com/questions/16169948/check-if-something-is-an-attribute-or-decorator-in-python
+        # TODO: mighe be better fixed in zope.schema - https://github.com/zopefoundation/zope.schema/issues/127
         self.schema = INamedTyped
         try:
             super().validate(value, IPluggableFileFieldValidation)

--- a/plone/namedfile/file.py
+++ b/plone/namedfile/file.py
@@ -390,7 +390,8 @@ class NamedBlobImage(NamedBlobFile):
         # Allow override of the image sniffer
         if contentType:
             self.contentType = contentType
-        exif_data = get_exif(self.data)
+        with self.open("r") as fp:
+            exif_data = get_exif(fp, self.contentType, self._width, self._height)
         if exif_data is not None:
             log.debug(
                 "Image contains Exif Informations. "
@@ -428,7 +429,7 @@ class NamedBlobImage(NamedBlobFile):
             res = getImageInfo(firstbytes)
         contentType, self._width, self._height = res
         if contentType:
-            self.contentType = contentType
+            self.contentType = contentType        
 
     data = property(NamedBlobFile._getData, _setData)
 

--- a/plone/namedfile/interfaces.py
+++ b/plone/namedfile/interfaces.py
@@ -10,6 +10,7 @@ _ = MessageFactory("plone")
 
 HAVE_BLOBS = True
 
+
 class ITyped(Interface):
 
     contentType = schema.NativeStringLine(
@@ -19,6 +20,7 @@ class ITyped(Interface):
         required=False,
         missing_value="",
     )
+
 
 class IFile(Interface):
 

--- a/plone/namedfile/interfaces.py
+++ b/plone/namedfile/interfaces.py
@@ -10,8 +10,7 @@ _ = MessageFactory("plone")
 
 HAVE_BLOBS = True
 
-
-class IFile(Interface):
+class ITyped(Interface):
 
     contentType = schema.NativeStringLine(
         title="Content Type",
@@ -20,6 +19,8 @@ class IFile(Interface):
         required=False,
         missing_value="",
     )
+
+class IFile(Interface):
 
     data = schema.Bytes(
         title="Data",
@@ -83,12 +84,15 @@ class INamed(Interface):
 
     filename = schema.TextLine(title="Filename", required=False, default=None)
 
+class INamedTyped(INamed, ITyped):
+    """An item with a filename and contentType"""
 
-class INamedFile(INamed, IFile):
+
+class INamedFile(INamedTyped, IFile):
     """A non-BLOB file with a filename"""
 
 
-class INamedImage(INamed, IImage):
+class INamedImage(INamedTyped, IImage):
     """A non-BLOB image with a filename"""
 
 

--- a/plone/namedfile/tests/test_storable.py
+++ b/plone/namedfile/tests/test_storable.py
@@ -99,16 +99,21 @@ class TestStorable(unittest.TestCase):
             self.assertIn('Exif', fi.exif)
             self.assertEqual(500, fi._width)
             self.assertEqual(200, fi._height)
-            self.assertLess(read_bytes, fi.getSize(), "Images should not need to read all data to get exif, dimensions, and also schema validation")
+            self.assertLess(read_bytes, fi.getSize(), "Images should not need to read all data to get exif, dimensions")
             self.assertEqual(blob_read, 3, "blob opening for getsize, get_exif and getImageInfo only")
             self.assertEqual(
                 blob_write,
                 1,
                 "Slow write to blob instead of os rename. Should be only 1 on __init__ to create empty file",
             )
-            blob_read = 0
 
-            blob_field = field.NamedBlobFile()
+            # Test validation which should also not read all the data.
+            blob_read = read_bytes = 0
+
+            blob_field = field.NamedBlobImage()
+            blob_field.validate(fi)
+            blob_field = field.NamedBlobFile()  # Image is subclass of file
             blob_field.validate(fi)
 
             self.assertEqual(blob_read, 0, "Validation is reading the whole blob in memory")
+            self.assertEqual(read_bytes, 0, "Validation is reading the whole blob in memory")

--- a/plone/namedfile/utils/__init__.py
+++ b/plone/namedfile/utils/__init__.py
@@ -227,17 +227,19 @@ def getImageInfo(data):
     return content_type, width, height
 
 
-def get_exif(image):
+def get_exif(image, content_type=None, width=None, height=None):
     #
     exif_data = None
-    image_data = _ensure_data(image)
 
-    content_type, width, height = getImageInfo(image_data)
+    if None in (content_type, width, height):
+        # if we already got the image info don't read the while file into memory
+        content_type, width, height = getImageInfo(_ensure_data(image))
     if content_type in ["image/jpeg", "image/tiff"]:
         # Only this two Image Types could have Exif informations
         # see http://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf
         try:
-            exif_data = piexif.load(image_data)
+            # if possible pass filename in instead to prevent reading all data into memory
+            exif_data = piexif.load(image.name if getattr(image, "name") else _ensure_data(image))
         except Exception as e:
             # TODO: determ wich error really happens
             # Should happen if data is to short --> first_bytes

--- a/plone/namedfile/utils/__init__.py
+++ b/plone/namedfile/utils/__init__.py
@@ -233,7 +233,8 @@ def get_exif(image, content_type=None, width=None, height=None):
 
     if None in (content_type, width, height):
         # if we already got the image info don't read the while file into memory
-        content_type, width, height = getImageInfo(_ensure_data(image))
+        image = _ensure_data(image)
+        content_type, width, height = getImageInfo(image)
     if content_type in ["image/jpeg", "image/tiff"]:
         # Only this two Image Types could have Exif informations
         # see http://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf


### PR DESCRIPTION
replaces #155

fixed #167

As mentioned in the comments perhaps a better long term fix is to change zope.schema to avoid accessing properies if they are decorators and instead using something like - https://stackoverflow.com/questions/16169948/check-if-something-is-an-attribute-or-decorator-in-python first
