### PR TITLE
Delete setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[isort]
-# black compatible Plone isort rules:
-profile = plone


### PR DESCRIPTION
The `isort` configuration left on `setup.cfg` is already on `pyproject.toml` :)