### PR TITLE
Require plone.scale 4.2.0 as minimum.

### DIFF
--- a/news/+scale.internal
+++ b/news/+scale.internal
@@ -1,0 +1,3 @@
+Require plone.scale 4.2.0 as minimum.
+Since our last release, we use a function introduced in that version.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "plone.memoize",
         "plone.protect",
         "plone.rfc822>=2.0.0",
-        "plone.scale[storage] >=3.0",
+        "plone.scale[storage]>=4.2.0",
         "plone.schemaeditor",
         "plone.supermodel",
         "Products.CMFCore",


### PR DESCRIPTION
Since our last release, we use a function introduced in that version. See https://github.com/plone/plone.namedfile/pull/133#discussion_r2099406585