### PR TITLE
Fix scale caching when _p_mtime is None

### DIFF
--- a/news/58.bugfix
+++ b/news/58.bugfix
@@ -1,0 +1,4 @@
+Fix image scale caching when ``_p_mtime`` is ``None`` (unsaved objects).
+``DateTime(None)`` returns "now", so every cache check saw a different timestamp and scales were regenerated on every access.
+Fall back to epoch (0) for a stable value.
+@jensens

--- a/src/plone/namedfile/scaling.py
+++ b/src/plone/namedfile/scaling.py
@@ -606,10 +606,15 @@ class ImageScaling(BrowserView):
         if fieldname is not None:
             field = getattr(context, fieldname, None)
             modified = getattr(field, "modified", None)
-            date = DateTime(modified or context._p_mtime)
+            mtime = modified or context._p_mtime
         else:
-            date = DateTime(context._p_mtime)
-        return date.millis()
+            mtime = context._p_mtime
+        # _p_mtime is None for unsaved objects (common in tests).
+        # Fall back to 0 so DateTime returns a stable epoch value
+        # instead of "now", which would break scale caching.
+        if mtime is None:
+            mtime = 0
+        return DateTime(mtime).millis()
 
     def scale(
         self,

--- a/src/plone/namedfile/tests/test_scaling.py
+++ b/src/plone/namedfile/tests/test_scaling.py
@@ -671,6 +671,22 @@ http://nohost/item/@@images/image-1200-....png 1200w"/>
         scale_b = self.scaling.scale("image", width=100, height=80)
         self.assertNotEqual(scale_a.data, scale_b.data)
 
+    def testScaleCachingWithNonePMtime(self):
+        # _p_mtime is None for unsaved objects (common in tests).
+        # Scales should still be cached rather than regenerated each time.
+        # See https://github.com/plone/plone.namedfile/issues/58
+        delattr(self.item.image, "_modified")
+        # _p_mtime is read-only on Persistent, so patch it on DummyContent
+        from unittest.mock import patch
+        from unittest.mock import PropertyMock
+
+        with patch.object(
+            DummyContent, "_p_mtime", new_callable=PropertyMock, return_value=None
+        ):
+            scale1 = self.scaling.scale("image", width=100, height=80)
+            scale2 = self.scaling.scale("image", width=100, height=80)
+            self.assertEqual(scale1.data, scale2.data)
+
     def testCustomSizeChange(self):
         # set custom image sizes & view a scale
         self.scaling.available_sizes = {"foo": (23, 23)}

--- a/src/plone/namedfile/tests/test_scaling.py
+++ b/src/plone/namedfile/tests/test_scaling.py
@@ -689,6 +689,7 @@ http://nohost/item/@@images/image-1200-....png 1200w"/>
             ),
         ):
             scale1 = self.scaling.scale("image", width=100, height=80)
+            wait_to_ensure_modified()
             scale2 = self.scaling.scale("image", width=100, height=80)
             self.assertEqual(scale1.data, scale2.data)
 

--- a/src/plone/namedfile/tests/test_scaling.py
+++ b/src/plone/namedfile/tests/test_scaling.py
@@ -680,9 +680,13 @@ http://nohost/item/@@images/image-1200-....png 1200w"/>
         from unittest.mock import patch
         from unittest.mock import PropertyMock
 
-        with patch.object(
-            DummyContent, "_p_mtime", new_callable=PropertyMock, return_value=None
-        ):
+        with (
+            patch.object(
+                DummyContent, "_p_mtime", new_callable=PropertyMock, return_value=None
+            ),
+            patch.object(
+                MockNamedImage, "_p_mtime", new_callable=PropertyMock, return_value=None
+            ),
             scale1 = self.scaling.scale("image", width=100, height=80)
             scale2 = self.scaling.scale("image", width=100, height=80)
             self.assertEqual(scale1.data, scale2.data)

--- a/src/plone/namedfile/tests/test_scaling.py
+++ b/src/plone/namedfile/tests/test_scaling.py
@@ -687,6 +687,7 @@ http://nohost/item/@@images/image-1200-....png 1200w"/>
             patch.object(
                 MockNamedImage, "_p_mtime", new_callable=PropertyMock, return_value=None
             ),
+        ):
             scale1 = self.scaling.scale("image", width=100, height=80)
             scale2 = self.scaling.scale("image", width=100, height=80)
             self.assertEqual(scale1.data, scale2.data)


### PR DESCRIPTION
## Summary

- When `_p_mtime` is `None` (unsaved persistent objects, common in tests), `DateTime(None)` returns "now" — a different value each call
- This broke scale caching: every access regenerated the scale because the object appeared "just modified"
- Fix: fall back to `0` (epoch) when mtime is `None`, giving a stable timestamp so the cache works

## Test plan

- [x] New test `testScaleCachingWithNonePMtime` verifies two consecutive scale requests with `_p_mtime=None` return the same cached data
- [x] All 51 existing scaling tests pass
- [x] Pre-commit QA passes

Fixes #58

🤖 Generated with [Claude Code](https://claude.ai/code)