### PR TITLE
Include exception in PIL image identification warning

### DIFF
--- a/news/184.bugfix
+++ b/news/184.bugfix
@@ -1,0 +1,2 @@
+Include actual exception in PIL image identification warning instead of generic message.
+@jensens

--- a/src/plone/namedfile/utils/__init__.py
+++ b/src/plone/namedfile/utils/__init__.py
@@ -240,14 +240,8 @@ def getImageInfo(data):
             img = PIL.Image.open(BytesIO(data))
             width, height = img.size
             content_type = PIL.Image.MIME[img.format]
-        except Exception:
-            # TODO: determ which error really happens
-            # Should happen if data is to short --> first_bytes
-            # happens also if data is an svg or another special format.
-            log.warning(
-                "PIL can not recognize the image. "
-                "Image is probably broken or of a non-supported format."
-            )
+        except Exception as e:
+            log.warning("Could not identify image with PIL: %s", e)
 
     log.debug(
         "Image Info (Type: %s, Width: %s, Height: %s)", content_type, width, height

--- a/src/plone/namedfile/utils/__init__.py
+++ b/src/plone/namedfile/utils/__init__.py
@@ -241,7 +241,11 @@ def getImageInfo(data):
             width, height = img.size
             content_type = PIL.Image.MIME[img.format]
         except Exception as e:
-            log.warning("Could not identify image with PIL: %s", e)
+            log.warning(
+                "PIL can not recognize the image. "
+                "Image is probably broken or of a non-supported format: %s",
+                e,
+            )
 
     log.debug(
         "Image Info (Type: %s, Width: %s, Height: %s)", content_type, width, height


### PR DESCRIPTION
## Summary

- Replace the generic *"Image is probably broken or of a non-supported format"* warning with the actual exception message
- Before: `PIL can not recognize the image. Image is probably broken or of a non-supported format.`
- After: `Could not identify image with PIL: could not create decoder object`
- Also removes the stale TODO comment

Fixes #184

🤖 Generated with [Claude Code](https://claude.ai/code)