### PR TITLE
Fix getattr without default in EXIF loading

### DIFF
--- a/news/192.bugfix
+++ b/news/192.bugfix
@@ -1,0 +1,2 @@
+Fix ``AttributeError`` when loading EXIF data from images without a ``name`` attribute (e.g. site logo from registry).
+@jensens

--- a/src/plone/namedfile/utils/__init__.py
+++ b/src/plone/namedfile/utils/__init__.py
@@ -269,12 +269,10 @@ def get_exif(image, content_type=None, width=None, height=None):
         try:
             # if possible pass filename in instead to prevent reading all data into memory
             exif_data = piexif.load(
-                image.name if getattr(image, "name") else _ensure_data(image)
+                image.name if getattr(image, "name", None) else _ensure_data(image)
             )
         except Exception as e:
-            # TODO: determ which error really happens
-            # Should happen if data is to short --> first_bytes
-            log.warn(e)
+            log.warning("Could not load EXIF data: %s", e)
             exif_data = exif_data = {
                 "0th": {
                     piexif.ImageIFD.XResolution: (width, 1),


### PR DESCRIPTION
## Summary

- `getattr(image, "name")` → `getattr(image, "name", None)` — prevents `AttributeError` when the image is raw bytes without a `name` attribute (e.g. site logo stored in registry)
- Replace deprecated `log.warn` with `log.warning` and include the actual exception

Fixes #192

🤖 Generated with [Claude Code](https://claude.ai/code)