### PR TITLE
Handle empty image fields in srcset() and picture()

### DIFF
--- a/news/202.bugfix
+++ b/news/202.bugfix
@@ -1,0 +1,2 @@
+Return ``None`` from ``srcset()`` and ``picture()`` when the image field is empty, consistent with ``tag()``.
+@jensens

--- a/src/plone/namedfile/scaling.py
+++ b/src/plone/namedfile/scaling.py
@@ -751,6 +751,8 @@ class ImageScaling(BrowserView):
 
         sourceset = picture_variant_config.get("sourceset")
         scale = self.scale(fieldname, sourceset[-1].get("scale"), pre=True)
+        if scale is None:
+            return None
         attributes = {}
         attributes["class"] = css_class and [css_class] or []
         if not attributes["class"]:
@@ -792,6 +794,8 @@ class ImageScaling(BrowserView):
             fieldname = primary.fieldname
 
         original_width, original_height = self.getImageSize(fieldname)
+        if not original_width or not original_height:
+            return None
 
         storage = getMultiAdapter(
             (self.context, functools.partial(self.modified, fieldname)),
@@ -851,6 +855,8 @@ class ImageScaling(BrowserView):
                     break
 
         scale = self.scale(fieldname=fieldname, scale=scale_in_src)
+        if scale is None:
+            return None
         attributes["src"] = scale.url
         if "width" not in attributes:
             attributes["width"] = scale.width

--- a/src/plone/namedfile/tests/test_scaling.py
+++ b/src/plone/namedfile/tests/test_scaling.py
@@ -627,6 +627,13 @@ http://nohost/item/@@images/image-1200-....png 1200w"/>
         foo = self.scaling.scale("image", scale="foo?")
         self.assertEqual(foo, None)
 
+    def testSrcsetEmptyField(self):
+        # srcset should return None for an empty image field
+        # See https://github.com/plone/plone.namedfile/issues/202
+        self.item.image = None
+        result = self.scaling.srcset("image", sizes="100vw")
+        self.assertIsNone(result)
+
     def testScaleInvalidation(self):
         dt = self.item.modified()
 


### PR DESCRIPTION
## Summary

- `srcset()` crashed with `AttributeError: 'NoneType' object has no attribute 'url'` when the image field was empty
- `picture()` had the same issue
- `tag()` already handled this by returning `None` — now `srcset()` and `picture()` do the same
- Added early return in `srcset()` when image dimensions are `(0, 0)` (empty field)
- Added `None` guard on `self.scale()` return in both `srcset()` and `picture()`

## Test plan

- [x] New test `testSrcsetEmptyField` verifies `srcset()` returns `None` for empty image
- [x] All 51 existing scaling tests pass

Fixes #202

🤖 Generated with [Claude Code](https://claude.ai/code)