### PR TITLE
Add Content-Disposition: inline with filename to @@display-file

### DIFF
--- a/news/205.bugfix
+++ b/news/205.bugfix
@@ -1,0 +1,2 @@
+Add ``Content-Disposition: inline`` with filename to ``@@display-file`` for allowed mimetypes, so browsers use the correct filename when saving files viewed inline.
+@jensens

--- a/src/plone/namedfile/browser.py
+++ b/src/plone/namedfile/browser.py
@@ -1,9 +1,11 @@
 from AccessControl.ZopeGuards import guarded_getattr
 from plone.namedfile.utils import extract_media_type
+from plone.namedfile.utils import safe_basename
 from plone.namedfile.utils import set_headers
 from plone.namedfile.utils import stream_data
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from Products.Five.browser import BrowserView
+from urllib.parse import quote
 from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
 from zope.publisher.interfaces import NotFound
@@ -198,3 +200,12 @@ class DisplayFile(Download):
                     return super().set_headers(file)
         canonical = self.get_canonical(file)
         set_headers(file, self.request.response, canonical=canonical)
+        # Add Content-Disposition: inline with filename so browsers use the
+        # correct name when saving files displayed inline (e.g. PDFs).
+        filename = safe_basename(getattr(file, "filename", None))
+        if filename:
+            filename = quote(filename.encode("utf-8"))
+            self.request.response.setHeader(
+                "Content-Disposition",
+                f"inline; filename*=UTF-8''{filename}",
+            )

--- a/src/plone/namedfile/tests/test_display_file.py
+++ b/src/plone/namedfile/tests/test_display_file.py
@@ -101,7 +101,10 @@ class TestAttackVectorNamedImage(unittest.TestCase):
         # Test that displaying this file inline works.
         browser = self.get_anon_browser()
         browser.open(base_url + f"/@@display-file/{self.field_name}")
-        self.assertIsNone(get_disposition_header(browser))
+        header = get_disposition_header(browser)
+        self.assertIsNotNone(header)
+        self.assertIn("inline", header)
+        self.assertIn("filename", header)
 
     def assert_display_inline_is_download(self, base_url):
         # Test that displaying this file inline turns into a download.

--- a/src/plone/namedfile/usage.rst
+++ b/src/plone/namedfile/usage.rst
@@ -328,6 +328,7 @@ We will test this with a dummy request, faking traversal::
     >>> request.response.getHeader('Content-Type')
     'text/plain'
     >>> request.response.getHeader('Content-Disposition')
+    "inline; filename*=UTF-8''test.txt"
 
     >>> request = TestRequest()
     >>> display_file = DisplayFile(container, request).publishTraverse(request, 'blob')
@@ -339,6 +340,7 @@ We will test this with a dummy request, faking traversal::
     >>> request.response.getHeader('Content-Type')
     'text/plain'
     >>> request.response.getHeader('Content-Disposition')
+    "inline; filename*=UTF-8''test.txt"
 
     >>> request = TestRequest()
     >>> display_file = DisplayFile(container, request).publishTraverse(request, 'image')


### PR DESCRIPTION
## Summary

- `@@display-file` now sets `Content-Disposition: inline; filename*=UTF-8''<name>` for allowed inline mimetypes
- Before: no header → browsers saved as generic "document.pdf"
- After: `inline` preserves in-browser display, `filename*` provides the correct name for "Save As"
- Disallowed mimetypes (SVG, HTML, JS) still get `attachment` (security)
- Files without a filename gracefully skip the header

This is a clean reimplementation of the idea from @aboycalledhero's accidental push (commit `1945506`, since reverted). Co-authored accordingly.

## Test plan

- [x] Updated `assert_display_inline_works` to verify `inline` + `filename` in header
- [x] All 20 display-file tests pass (including SVG/HTML security tests)
- [x] Pre-commit QA passes

Fixes #205

🤖 Generated with [Claude Code](https://claude.ai/code)